### PR TITLE
Provide more generic 'point' interface

### DIFF
--- a/fastpair/test/test_fastpair.py
+++ b/fastpair/test/test_fastpair.py
@@ -191,7 +191,7 @@ class TestFastPairs:
         assert abs(res[0] - neigh["dist"]) < 1e-8
         assert res[1] == neigh["neigh"]
 
-    def test_merge_and_merge_closest(self):
+    def test_merge_closest(self):
         # Still failing sometimes...
         ps = PointSet()
         fp1 = FastPair().build(ps)


### PR DESCRIPTION
This ‘feature’ allows more generic point objects that might not be
tuples. As long as the user can supply a distance and merge (interact)
function that takes the point class as input, it should still work!