### PR TITLE
Cleanup methods to reduce 'extra' bloat

### DIFF
--- a/fastpair/test/test_fastpair.py
+++ b/fastpair/test/test_fastpair.py
@@ -181,7 +181,7 @@ class TestFastPairs:
         assert len(fp) == len(ps)
         old = ps[0]  # Just grab the first point...
         new = rand_tuple(len(ps[0]))
-        res = fp.update_point(old, new)
+        fp._update_point(old, new)
         assert old not in fp
         assert new in fp
         assert len(fp) == len(ps)  # Size shouldn't change
@@ -201,7 +201,7 @@ class TestFastPairs:
             dist, (a, b) = fp1.closest_pair()
             new = interact(a, b)
             fp1 -= b  # Drop b
-            fp1.update_point(a, new)
+            fp1._update_point(a, new)
             fp2.merge_closest()
             n -= 1
         assert len(fp1) == len(fp2) == 1 # == len(fp2)


### PR DESCRIPTION
This should increase our test coverage stats, and improve the ‘public’
API. We don’t want users using ‘update_point’ or ‘find_neighbor’…