### PR TITLE
kicking off #20 - modernizing `fastpairs`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,67 @@
+ name: Continuous Integration
+ 
+ on:
+   push:
+     branches:
+     - '*'
+   pull_request:
+     branches:
+     - '*'
+   schedule:
+     - cron: '59 23 * * *'
+   workflow_dispatch:
+    inputs:
+      version:
+        description: Manual CI Run
+        default: test
+        required: false
+
+ jobs:
+   tests:
+     name: ${{ matrix.os }}, ${{ matrix.environment-file }}
+     runs-on: ${{ matrix.os }}
+     timeout-minutes: 30
+     strategy:
+       matrix:
+         os: [ubuntu-latest]
+         environment-file: [
+            ci/py312-latest.yaml,
+         ]
+       fail-fast: false
+
+     defaults:
+       run:
+         shell: bash -l {0}
+
+     steps:
+       - name: checkout repo
+         uses: actions/checkout@v4
+         with:
+           fetch-depth: 0 # Fetch all history for all branches and tags.
+       
+       - name: setup micromamba
+         uses: mamba-org/setup-micromamba@v1
+         with:
+           environment-file: ${{ matrix.environment-file }}
+           micromamba-version: "latest"
+
+       - name: install package
+         run: "pip install -e ."
+
+       - name: environment info
+         run: "micromamba info && micromamba list"
+       
+       - name: run tests
+         run: |
+           pytest \
+           fastpair/ \
+           --verbose \
+           -r a \
+           --color yes \
+           --cov fastpair \
+           --cov-append \
+           --cov-report term-missing \
+           --cov-report xml .
+       
+       - name: codecov
+         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# macOS
+*.DS_Store

--- a/ci/py312-latest.yaml
+++ b/ci/py312-latest.yaml
@@ -1,0 +1,10 @@
+name: py312-latest
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.12
+  - scipy=1.11
+  # testing
+  - pytest
+  - pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -22,36 +22,7 @@ except ImportError:
 PACKAGE_NAME = "FastPair"
 DESCRIPTION = "FastPair: Data-structure for the dynamic closest-pair problem."
 
-MAJOR = 0
-MINOR = 1
-MICRO = 0
-ISRELEASED = False
-VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
-QUALIFIER = ''
-FULLVERSION = VERSION
-if not ISRELEASED:
-    FULLVERSION += '.dev'
-    try:
-        import subprocess
-        try:
-            pipe = subprocess.Popen(["git", "rev-parse", "--short", "HEAD"],
-                                    stdout=subprocess.PIPE).stdout
-        except OSError:
-            # msysgit compatibility
-            pipe = subprocess.Popen(
-                ["git.cmd", "describe", "HEAD"],
-                stdout=subprocess.PIPE).stdout
-        rev = pipe.read().strip()
-        # Makes distutils blow up on Python 2.7
-        if sys.version_info[0] >= 3:
-            rev = rev.decode('ascii')
-        FULLVERSION = '%d.%d.%d.dev-%s' % (MAJOR, MINOR, MICRO, rev)
-    except:
-        warnings.warn("Couldn't get git revision")
-else:
-    FULLVERSION += QUALIFIER
-
-setup(name=PACKAGE_NAME, version=FULLVERSION, description=DESCRIPTION,
+setup(name=PACKAGE_NAME, description=DESCRIPTION,
       license='MIT', author='Carson J. Q. Farmer',
       author_email='carsonfarmer@gmail.com',
       keywords="closest-pair points algorithm fastpair",

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,9 @@ except ImportError:
 
 PACKAGE_NAME = "FastPair"
 DESCRIPTION = "FastPair: Data-structure for the dynamic closest-pair problem."
+FULLVERSION = "v0.1.0"
 
-setup(name=PACKAGE_NAME, description=DESCRIPTION,
+setup(name=PACKAGE_NAME, version=FULLVERSION, description=DESCRIPTION,
       license='MIT', author='Carson J. Q. Farmer',
       author_email='carsonfarmer@gmail.com',
       keywords="closest-pair points algorithm fastpair",


### PR DESCRIPTION
This PR kick of #20:
* removes versioning from `setup.py` that was causing an error – #23 
* adds an initial CI environment and workflow for testing – with a pinned `scipy=1.11` – #22 
* CI [tests pass](https://github.com/jGaboardi/fastpair/actions/runs/9236827212/job/25413092658#step:6:17) in my fork
* The action will only run in this fork once merged

> [!IMPORTANT]
> @carsonfarmer Perhaps before merging this PR:
> * We should tag the current `main` with `fastpair==0.1.0` to give a good point-in-time break
> * Then I can update this PR and add back in a simple `version=0.1.0` into the `setup.py` 
> * Once `pyproejct.toml` & `setuptools-scm` are adopted as described in #20, versioning will be automated by manual tagging.