### PR TITLE
add `pre-commit-config.yaml` - #20

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+files: "fastpair\/"
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.4.8"
+    hooks:
+      - id: ruff
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ Repository = "https://github.com/carsonfarmer/fastpair"
 tests = [
     "codecov",
     "coverage",
+    "pre-commit",
     "pytest",
     "pytest-cov",
     "ruff",


### PR DESCRIPTION
* This PR adds `pre-commit-config.yaml` - #20
* In order to utilize locally, developers must:
   * install pre-commit itself[^1]; and
   * install the hook[^2]
* @carsonfarmer we'll also want to enable [`pre-commit.ci`](https://pre-commit.ci) which will run before any testing workflows on PRs to ensure conformity


[^1]: https://pre-commit.com/#installation
[^2]: https://pre-commit.com/#3-install-the-git-hook-scripts