### PR TITLE
fix #22 - update min req & boost CI suite #20

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,13 +30,13 @@
             ci/py312-latest.yaml,
             ci/py312-dev.yaml,
          ]
-       include:
-         - environment-file: ci/py312-latest.yaml
-           os: macos-latest
-         - environment-file: ci/py312-latest.yaml
-           os: macos-14 # Apple Silicon
-         - environment-file: ci/py312-latest.yaml
-           os: windows-latest
+         include:
+           - environment-file: ci/py312-latest.yaml
+             os: macos-latest
+           - environment-file: ci/py312-latest.yaml
+             os: macos-14 # Apple Silicon
+           - environment-file: ci/py312-latest.yaml
+             os: windows-latest
        fail-fast: false
 
      defaults:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,8 +25,18 @@
        matrix:
          os: [ubuntu-latest]
          environment-file: [
+            ci/py310-oldest.yaml,
+            ci/py311-latest.yaml,
             ci/py312-latest.yaml,
+            ci/py312-dev.yaml,
          ]
+       include:
+         - environment-file: ci/py312-latest.yaml
+           os: macos-latest
+         - environment-file: ci/py312-latest.yaml
+           os: macos-14 # Apple Silicon
+         - environment-file: ci/py312-latest.yaml
+           os: windows-latest
        fail-fast: false
 
      defaults:

--- a/ci/py310-oldest.yaml
+++ b/ci/py310-oldest.yaml
@@ -1,9 +1,10 @@
-name: py312-latest
+name: py310-oldest
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
-  - scipy
+  - python=3.10
+  - numpy=1.24
+  - scipy=1.10
   # testing
   - pytest
   - pytest-cov

--- a/ci/py311-latest.yaml
+++ b/ci/py311-latest.yaml
@@ -2,7 +2,7 @@ name: py311-latest
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
+  - python=3.11
   - scipy
   # testing
   - pytest

--- a/ci/py311-latest.yaml
+++ b/ci/py311-latest.yaml
@@ -1,4 +1,4 @@
-name: py312-latest
+name: py311-latest
 channels:
   - conda-forge
 dependencies:

--- a/ci/py312-dev.yaml
+++ b/ci/py312-dev.yaml
@@ -1,0 +1,16 @@
+name: py312-dev
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - pip
+  # testing
+  - pytest
+  - pytest-cov
+  - pip:
+    # nightly builds
+    - --pre \
+      --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple  \
+      --extra-index-url https://pypi.org/simple
+    - numpy
+    - scipy

--- a/fastpair/test/test_fastpair.py
+++ b/fastpair/test/test_fastpair.py
@@ -15,7 +15,6 @@ from types import FunctionType
 
 import numpy as np
 import pytest
-from scipy import array, mean
 
 from fastpair import FastPair
 
@@ -70,7 +69,7 @@ def rand_tuple(dim=2):
 
 def interact(u, v):
     """Compute element-wise mean(s) from two arrays."""
-    return tuple(mean(array([u, v]), axis=0))
+    return tuple(np.mean(np.array([u, v]), axis=0))
 
 
 # Setup fixtures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ classifiers = [
 
 requires-python = ">=3.10"
 dependencies = [
-    "scipy>=1.10,<1.12",
+    "numpy>=1.24",
+    "scipy>=1.10",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR:
* resolves #22 
   * swaps put using old `scipy` methods for `numpy` ones
* set minimum required version from [SPEC000](https://scientific-python.org/specs/spec-0000/)
* fill out CI suite with oldest Python 3.10 to bleeding edge Python 3.12
   * test latest Python 3.12 against intel macOS & arm macOS + windows 
* xref #20 