### PR TITLE
adding first notebook - basic usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-files: "fastpair\/"
+files: "fastpair\/|notebooks\/"
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.4.8"

--- a/notebooks/basic_usage.ipynb
+++ b/notebooks/basic_usage.ipynb
@@ -1,0 +1,1116 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fc0bc877-aa93-40af-9b4a-4d9d89ded2b9",
+   "metadata": {},
+   "source": [
+    "# Basics of FastPair\n",
+    "\n",
+    "1. Setup\n",
+    "2. Properties\n",
+    "3. Appending Values & Vizualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2da42c3d-a668-456c-9d05-5b826d2ca963",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:47.717373Z",
+     "iopub.status.busy": "2024-06-12T02:00:47.717160Z",
+     "iopub.status.idle": "2024-06-12T02:00:47.752407Z",
+     "shell.execute_reply": "2024-06-12T02:00:47.751967Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:47.717349Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Last updated: 2024-06-11T22:00:47.741779-04:00\n",
+      "\n",
+      "Python implementation: CPython\n",
+      "Python version       : 3.12.3\n",
+      "IPython version      : 8.25.0\n",
+      "\n",
+      "Compiler    : Clang 16.0.6 \n",
+      "OS          : Darwin\n",
+      "Release     : 23.5.0\n",
+      "Machine     : arm64\n",
+      "Processor   : arm\n",
+      "CPU cores   : 8\n",
+      "Architecture: 64bit\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%config InlineBackend.figure_format = \"retina\"\n",
+    "%load_ext watermark\n",
+    "%watermark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5f2c2691-2f11-4649-aafd-eaf734d5c368",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:47.753362Z",
+     "iopub.status.busy": "2024-06-12T02:00:47.753168Z",
+     "iopub.status.idle": "2024-06-12T02:00:47.977527Z",
+     "shell.execute_reply": "2024-06-12T02:00:47.977286Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:47.753345Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Watermark: 2.4.3\n",
+      "\n",
+      "matplotlib: 3.9.0\n",
+      "fastpair  : 0.1.1.dev8+g5f8e7a5.d20240611\n",
+      "numpy     : 1.26.4\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy\n",
+    "\n",
+    "import fastpair\n",
+    "\n",
+    "%watermark -w\n",
+    "%watermark -iv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f7e9080-ff0d-4a6d-8cdc-e7a7b4e71946",
+   "metadata": {},
+   "source": [
+    "---------------------------------\n",
+    "\n",
+    "## 1. Setup\n",
+    "\n",
+    "The following helper function will be used the generate random tuples of points in the example.\n",
+    "\n",
+    "* A reproducibile state can be set with the `seed` argument.\n",
+    "* Use the `size` argument to indicate the tuple dimensions.\n",
+    "* Set the `n` argument for the number of desired points\n",
+    "* `low` and `high` control for minimum and maximum values, respectively.\n",
+    "* The [desired distribution](https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.default_rng) is set in `sample`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "26917e2e-d996-469e-9028-3edd638ffe10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:47.978599Z",
+     "iopub.status.busy": "2024-06-12T02:00:47.978494Z",
+     "iopub.status.idle": "2024-06-12T02:00:47.980383Z",
+     "shell.execute_reply": "2024-06-12T02:00:47.980190Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:47.978592Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def random_points(\n",
+    "    seed: int = 0,\n",
+    "    size: int | tuple = (2),\n",
+    "    n: int = 1,\n",
+    "    low: int = 0,\n",
+    "    high: int = 20,\n",
+    "    sample: str = \"integers\",\n",
+    ") -> list[tuple[float]]:\n",
+    "    rng = numpy.random.default_rng(seed)\n",
+    "    return [\n",
+    "        tuple(getattr(rng, sample)(low=low, high=high, size=size)) for i in range(n)\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea1a2cd7-7822-4fbc-af59-d1587dc72e9c",
+   "metadata": {},
+   "source": [
+    "Generate a single 1D point from seed `0`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e7078d76-f6db-43c9-aff8-8c541ea385f9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:47.980711Z",
+     "iopub.status.busy": "2024-06-12T02:00:47.980639Z",
+     "iopub.status.idle": "2024-06-12T02:00:47.983242Z",
+     "shell.execute_reply": "2024-06-12T02:00:47.983070Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:47.980703Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(9,)]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random_points(1, 1, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc8f9d0e-fff0-4231-b650-c9f107c9e535",
+   "metadata": {},
+   "source": [
+    "Generate 3 2D points from seed `1`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c9a81f46-a864-4d96-a9a3-9e801a8a6e42",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:47.983606Z",
+     "iopub.status.busy": "2024-06-12T02:00:47.983545Z",
+     "iopub.status.idle": "2024-06-12T02:00:47.985417Z",
+     "shell.execute_reply": "2024-06-12T02:00:47.985231Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:47.983599Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(9, 10), (15, 19), (0, 2)]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "random_points(1, (2), 3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a01e92a-78cd-4ced-ac36-868e3ae74969",
+   "metadata": {},
+   "source": [
+    "---------------------\n",
+    "\n",
+    "## 2. Properties\n",
+    "\n",
+    "The simplest way to use a `FastPair` data-structure is to initialize one and then update it with data points (via the `+=` operator), which we will explore later. In this first example, we create a sequence of 3 2D random integers and add them to a `FastPair` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "119645fe-c0ca-4b9f-a074-9a3c80a24204",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:47.985856Z",
+     "iopub.status.busy": "2024-06-12T02:00:47.985753Z",
+     "iopub.status.idle": "2024-06-12T02:00:47.987630Z",
+     "shell.execute_reply": "2024-06-12T02:00:47.987468Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:47.985849Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(9, 10), (15, 19), (0, 2)]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "points = random_points(1, (2), 3)\n",
+    "points"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f483bbe-9712-436a-9d77-edf5ea63c3f6",
+   "metadata": {},
+   "source": [
+    "Create empty data-structure with default values:\n",
+    "\n",
+    "* `min_points=10`\n",
+    "* `default=scipy.spatial.distance.euclidean`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7e37b5d2-e626-486d-a02f-c982eea73907",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:47.987966Z",
+     "iopub.status.busy": "2024-06-12T02:00:47.987901Z",
+     "iopub.status.idle": "2024-06-12T02:00:47.989627Z",
+     "shell.execute_reply": "2024-06-12T02:00:47.989454Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:47.987959Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<fastpair.base.FastPair at 0x14966b050>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fp = fastpair.FastPair()\n",
+    "fp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b2f499d-abbf-4e55-8851-0247865578ef",
+   "metadata": {},
+   "source": [
+    "Add points all at once and build conga line to start:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "895e21eb-9449-4aa5-999b-5ac13f9e4219",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:47.989916Z",
+     "iopub.status.busy": "2024-06-12T02:00:47.989858Z",
+     "iopub.status.idle": "2024-06-12T02:00:47.991625Z",
+     "shell.execute_reply": "2024-06-12T02:00:47.991426Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:47.989910Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<fastpair.base.FastPair at 0x14966b050>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fp.build(points)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93727945-6e73-497b-81ab-2f90a6d47099",
+   "metadata": {},
+   "source": [
+    "### `FastPair` has several useful properties and methods\n",
+    "\n",
+    "1. Checking the size of the data-structure (i.e., how many points are currently stored).\n",
+    "2. Testing for containment of a given point\n",
+    "3. Various methods for computing the closest pair\n",
+    "4. Finding the neighbor of a given point\n",
+    "5. Computing multiple distances at once \n",
+    "6. ... and *even merging points (clusters)*.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "<b>Important:</b> merging functionality is not currently implemented\n",
+    "</div>\n",
+    "\n",
+    "#### Checking size\n",
+    "\n",
+    "How many point are currently stored?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "01160597-4c0f-4cd1-9cd4-b7dc8bce6b2a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:47.992043Z",
+     "iopub.status.busy": "2024-06-12T02:00:47.991982Z",
+     "iopub.status.idle": "2024-06-12T02:00:47.994019Z",
+     "shell.execute_reply": "2024-06-12T02:00:47.993813Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:47.992036Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(fp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "810822de-e09a-45b2-82c9-9d6b27cb0053",
+   "metadata": {},
+   "source": [
+    "#### Testing containment\n",
+    "\n",
+    "Is the first element of `points` in the `fp` instance?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "9d7adeb7-36a4-41e7-93e9-9a1fee6edbed",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:47.994442Z",
+     "iopub.status.busy": "2024-06-12T02:00:47.994356Z",
+     "iopub.status.idle": "2024-06-12T02:00:47.996536Z",
+     "shell.execute_reply": "2024-06-12T02:00:47.996174Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:47.994436Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "points[0] in fp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e039729-481c-46a9-a4df-3d2f92083c80",
+   "metadata": {},
+   "source": [
+    "Is a point as `(25, 25)` in the `fp` instance?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "30355b1a-3757-43c0-ab95-0733f4f50e81",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:47.997338Z",
+     "iopub.status.busy": "2024-06-12T02:00:47.997263Z",
+     "iopub.status.idle": "2024-06-12T02:00:47.999418Z",
+     "shell.execute_reply": "2024-06-12T02:00:47.999172Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:47.997331Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(25, 25) in fp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "caadbd5c-d7c4-4445-ba8c-ef621580d5e6",
+   "metadata": {},
+   "source": [
+    "#### Computing the closest pair\n",
+    "\n",
+    "Simply call the `fp` instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "78034246-f548-4a1c-9872-ea071462c058",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.001699Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.001534Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.003536Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.003330Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.001690Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10.816653826391969, ((9, 10), (15, 19)))"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fp()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "237107b0-265c-451a-85cc-2dfdf5596754",
+   "metadata": {},
+   "source": [
+    "Call the `closest_pair` method of the `fp` instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "9f7315f7-72d0-4693-9808-d1e325f93c8d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.004333Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.004247Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.006416Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.006222Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.004324Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10.816653826391969, ((9, 10), (15, 19)))"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fp.closest_pair()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d68a8c5a-094a-4e3e-bce5-f8d3684943e8",
+   "metadata": {},
+   "source": [
+    "Call the `closest_pair_brute_force` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "37366768-415c-42ab-9c18-110750160483",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.006952Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.006878Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.008937Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.008735Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.006944Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(10.816653826391969, ((9, 10), (15, 19)))"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fp.closest_pair_brute_force()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88aa5b68-bdaa-4fcd-a570-036e6caf85d3",
+   "metadata": {},
+   "source": [
+    "#### Finding the neighbor of a given point\n",
+    "\n",
+    "What's the neighbor of the 2nd element of `points`?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ac10107e-1f1b-437c-a0c5-0323460a9bff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.009444Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.009343Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.011279Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.011088Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.009437Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(9, 10)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "neigh = fp._find_neighbor(points[1])\n",
+    "neigh[\"neigh\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f16b9c4c-91b2-415b-bb23-c0ef870cfde6",
+   "metadata": {},
+   "source": [
+    "How far away is it?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "9284e7a7-0765-4d9e-9f51-0c64217fe778",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.011695Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.011622Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.014009Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.013783Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.011682Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10.816653826391969"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "neigh[\"dist\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddfa1457-7a75-4074-8da6-4120653068c9",
+   "metadata": {},
+   "source": [
+    "How about about a point outside `points` set?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "2e255c57-90c4-4596-8f31-9f352cc89357",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.014826Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.014632Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.016780Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.016591Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.014816Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(15, 19)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "neigh = fp._find_neighbor((25, 25))\n",
+    "neigh[\"neigh\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "dcc5c91e-1ab4-4ee9-acad-a9a349de8793",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.017226Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.017160Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.019127Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.018937Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.017219Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "11.661903789690601"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "neigh[\"dist\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19212ce6-8cfd-4a1d-99c4-ed34412628a7",
+   "metadata": {},
+   "source": [
+    "#### Computing multiple distances at once\n",
+    "\n",
+    "How about the distance from a new point at `(-1, -1)` to all points in `fp`?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "05d78d6f-1f73-4718-b070-cc81e27154ec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.019873Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.019765Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.021810Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.021605Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.019866Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((14.866068747318506, (9, 10)),\n",
+       " (25.612496949731394, (15, 19)),\n",
+       " (3.1622776601683795, (0, 2)))"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tuple(fp.sdist((-1, -1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d461009-a5c8-49af-b337-9706ab3f96ff",
+   "metadata": {},
+   "source": [
+    "--------------\n",
+    "\n",
+    "## 3. Appending Values & Vizualization\n",
+    "\n",
+    "A key strength of `fastpair` is the ability to incorporate additional points dynamically (or remove them) while the data-structure responds and updates accordingly (see this paper referenced below for details).\n",
+    "\n",
+    "* ***David Eppstein*** (2001). *Fast hierarchical clustering and other applications of dynamic closest pairs*. ACM J. Exp. Algorithmics 5 (2000), 1–es. doi: [10.1145/351827.351829](https://doi.org/10.1145/351827.351829)\n",
+    "\n",
+    "### Create a fresh `FastPair` instance\n",
+    "\n",
+    "4 2D points from a random seed of `101`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "4da8f641-5732-4932-8d6e-c181bd7af500",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.022233Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.022170Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.025391Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.025178Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.022225Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<fastpair.base.FastPair at 0x1073c3b30>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "points = random_points(101, (2), 4)\n",
+    "fp = fastpair.FastPair()\n",
+    "fp.build(points)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ffc8ae9-59a2-44bb-81ad-72e0beb524be",
+   "metadata": {},
+   "source": [
+    "Query the closest pair."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "9382b0a5-e16f-4bf2-a537-cc442fd7c719",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.025916Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.025812Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.027816Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.027601Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.025909Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(5.0, ((6, 18), (2, 15)))"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dist, (a, b) = fp.closest_pair()\n",
+    "dist, (a, b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b630b4ed-2c34-4dc1-a7c2-63293e3aab2a",
+   "metadata": {},
+   "source": [
+    "Vizualize the current set.\n",
+    "\n",
+    "* 4 initial points in `\"cadetblue\"`\n",
+    "* Current closest pair in `\"red\"`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "e544b5d1-6489-43a1-86f0-60b7999870ec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.028241Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.028170Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.124236Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.123985Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.028235Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABHgAAANlCAYAAAAHHU6IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy80BEi2AAAACXBIWXMAAB7CAAAewgFu0HU+AACjtElEQVR4nOzdeVxV1f7/8fdhUgYFhFRQFCwBhxxKzKlAS81yzrThppbVHZp/fat7v3Utm+e6eb95KzWtrGwwK8vKTO06pZizCGqQIGiC4gAo0/79oZwHyHSAw9ln4+v5ePBwH/Y6a33OAY6cN2utbTMMwxAAAAAAAAAsy8PsAgAAAAAAANAwBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwA0IRMnTpVNptNNptN8+bNM7scNBHz5s2zf19NnTrVtDoSEhLsdaxcudK0OmA97vI9DABAY/IyuwAAgHT8+HEtXbpUy5YtU2Jiog4fPqzs7Gz5+PgoODhY0dHRiouL0+jRo9W/f3+zywVQjs1mq1N7T09PFRcXN0otGzdu1LvvvquVK1cqIyNDktS+fXslJCTo1ltvVVxcXKOMCwAAzMcMHgAwUX5+vp599llFRkbqhhtu0Jw5c7R161ZlZmaqsLBQJ0+eVHp6upYvX67nn39eAwYMUExMjD766CMZhmF2+ecFZkXBCgoLC3Xffffpsssu06xZs5SUlKQTJ07oxIkTSkpK0qxZs3TZZZfpgQceUFFRkdnluqW0tDT7z3pkZKTZ5cAJmLkF4HzDDB4AMMn+/fs1atQobdu2rcLnO3TooB49euiCCy5QSUmJDh48qK1bt+rQoUOSpJSUFN10001KT0/Xww8/bEbpAKpx11131drG09PT6ePecccdeu+99+y3O3XqpH79+kmS1q9fr99++02GYej111/X8ePHNWfOHKfXAAAAzEXAAwAmSEtLU//+/XXw4EFJZ5Z43Hjjjfrf//1fdevWrVJ7wzCUmJiomTNnasGCBSotLVV+fr6ry8Z5aurUqW7x128r7Lvz73//2+Vjzp071x7ueHh46JVXXtG9994rD48zE7VLS0v1xhtv6MEHH1Rpaanmzp2r+Ph4TZ482eW1msVdvocBAGhMLNECABcrLCzU9ddfbw93mjdvrkWLFmnBggVVhjvSmQAoLi5O7733nrZu3aru3bu7smQAbur06dN64okn7Lcffvhh3X///fZwRzoT+tx///166KGH7J+bPn26CgsLXVkqAABoZAQ8AOBiL774ohITE+2358+fr7Fjxzp8/+7du2v9+vUaOnRoI1QHwEq++uorpaenS5ICAwP1z3/+s9q206dPV8uWLSVJv//+u7755huX1AgAAFyDgAcAXKigoEBvvPGG/fb48eM1ceLEOvfj7++vgQMHNriekydP6o033tDw4cPVvn17NW/eXMHBwerevbvuvvtu/fLLLw73lZ6erhkzZuiKK65QmzZt1KxZM/n4+CgkJEQ9e/bUTTfdpFmzZtlnLtXEMAx98cUXmjJliqKjoxUYGKjmzZsrIiJCY8eO1fz58x2+CtHu3bv18MMPq1+/fgoNDZWPj4+aN2+u1q1b69JLL9Wtt96q+fPn6+jRoxXuFxkZKZvNpvnz59s/d+utt9o37Cz/UX4GRV1Ut6nr8uXLdeONN+rCCy+Ur6+vLrjgAl1++eX697//rdOnTzvU9x9//KF3331XU6ZMUe/evdWqVSt5e3srKChIsbGxuvXWW/X999871JcjG5WuXLnS3iYhIcH++W+//VY33nijOnfurICAANlsNr3++usOjXsuRy+TXlRUpA8++EDjx49Xp06dFBAQIC8vL7Vo0UIXXXSRhg8frunTp2vDhg31qsOdLF682H48adIk+fn5VdvWz8+vwuvNF1980eDxy35ObDab0tLSam3vyKblVbXJz8/Xm2++qUGDBtlfXyIiInTjjTdqzZo1tY5b0/dw2bmoqCj7537//fcqf9aru2Laxo0bdffdd+uSSy5RcHCwvLy85Ovrq7CwMPXr109//etf9cknnygvL6/WWh2xadMmPffccxo5cqT9e9zHx0dt2rTRgAED9Oijj2r//v0O9VXV13D37t26//771bVrV7Vs2VItW7ZUjx499Nhjjzn0Gi6d+f9u8eLFuvfee+1fNx8fHwUEBCgyMlLjxo3TnDlzHJpJVtfXl7LvoVtvvdXedv78+VV+Pcv3BwCWZwAAXOa9994zJNk/Vq9e7dT+p0yZYu/73XffrbHt119/bbRt27ZCPVV93HTTTUZeXl6Nfb311luGr69vrX1JMgYOHFhjX1u3bjV69epVaz8xMTHGzp07a+zr8ccfNzw9PR2q6+abb65w344dOzp0P0nG448/XmMd1UlNTbX30bFjR6OwsNC48847axyrS5cuRnJyco39/utf/3L4cQ8ZMsTIzs6usb93333X3n7KlClVtlmxYoW9TXx8vJGbm2uMGzeuyjFfe+21ej1f8fHx9j5WrFhRZZvk5GSjS5cuDn/t9uzZU69ayivfn6uFhYXZx/7www9rbb9gwQJ7+3bt2jV4/PI/J6mpqbW2d+Q16tw2O3furPVrOn369BrHrel7uPw5Rz7KKyoqqvVntvzHo48+WutzVJu4uDiHxvL29jZeeOGFWvs792v49ttvG82aNau23+DgYOPLL7+ssc/169cbAQEBDtUZGRlp/PrrrzX2V9fXl/LfQ7V9xMfH1+XpBwC3xibLAOBCP/30k/24Q4cOTpmFUx8LFy7UzTffrJKSEklnruozaNAgXXTRRTp58qT++9//KjMzU5L04YcfKjU1VT/99JOaN29eqa/Fixfrz3/+s/12y5Yt1b9/f7Vv315eXl46duyYUlJStGPHjlr/Uvvzzz9r1KhROn78uCTJ29tbcXFx6ty5s7y9vZWWlqbVq1fr1KlTSk5O1oABA7Ru3Tp16dKlUl//+te/NGPGDPvt0NBQ9evXT2FhYbLZbDpy5Ih2796tpKQk+/NQ3pQpU5STk6Ply5dr9+7dkqQrr7xSsbGxldr27du3xsflqEceeURvv/22JKlHjx7q1auXDMPQpk2btGvXLklSUlKShgwZonXr1ikiIqLKfjIzM+2PqVOnTurSpYsuuOACNW/eXLm5udq+fbt27twp6cz35FVXXaX169erWbNmTnkchmHoT3/6k5YsWSKbzaY+ffqoa9euMgxDO3bsqHYWREOdOHFCV111lX3JkoeHh3r37q0uXbooICBA+fn5OnDggLZu3ars7OxGqeHnn3/Whg0bdOjQIXl6eio0NFQ9e/bUgAED5O/v79Sxjh07pqysLPvtSy65pNb7lG9z4MABHT9+3L5syx1lZmbqqquuUlZWloKCgnT55Zerbdu2ys7O1k8//aRjx45Jkp588kl17dpVkyZNqvMYXbp00V133aUTJ07YN6tu0aKFQ5tQP/TQQ/afWUlq166d+vbtqwsuuEClpaXKycnRrl27lJycXOe6qlM2M6dZs2bq1q2bLrroIgUGBsowDGVlZemXX35Rdna2ioqK9Mgjj0iSw1dc/PLLL3X//ffbH8ugQYMUEBCglJQUrVmzRqWlpTp69KgmTJigr7/+WsOHD6+yn6NHj+rkyZOSpNatW6tbt25q3769/P39lZ+fr71792rDhg0qLi5WWlqa4uPj9euvv+qiiy6qtUZHXl+uuuoqBQQEaPfu3Vq+fLkkKTY2VldeeWWl/jp37uzQcwMAlmBmugQA55sLL7zQ/lfD66+/3un9O/LX8b1791b4y2rfvn0rzWIoKSkxXnnlFcPDw8Pe7p577qmyv/Kzbe6+++5qZ/ucOHHC+OSTT4xHHnmkyvNZWVlG69at7X1NnjzZyMzMrNTu4MGDFf5ye/HFFxvFxcUV2hQVFRmhoaH2Ns8995xRWFhY5bg5OTnG3Llzq/1Ld11mRdVV+Rk83t7ehiQjJCTE+P777yu1/eqrr4yWLVva2w8fPrzafufMmWPMnDnTyMjIqLbN1q1bjT59+tj7e+qpp6ptW9cZPF5eXvavzbZt2yq1PXXqVLVj1aS2GTyvv/66/XzXrl2N3bt3V9lPaWmpsWHDBuOvf/2rsX///nrVUl7ZmDV9+Pn5GXfffbdx6NChBo9X5pdffqkwRn5+fq33ycvLq3CfDRs2NKiGxp7BUzaT5JFHHqn02pKTk2MMGTLE3rZTp05GaWlplX068j187oy62mRnZ9u/1z09PY158+ZVO35mZqbxxhtvGLNnz66139r89a9/Nb755ptqv97FxcXGu+++a/j7+9tfW3777bdq+yv/NfTx8TE8PDyMV155xSgpKanQbufOnUa3bt3sbdu2bWscOXKkyj7Xr19v/O///q+xffv2asc9dOiQccstt9j7u/LKK6ttW9/XF0e+7gDQlBDwAIALlf1iKsl44oknnN6/I2+eJk+ebG9z0UUXGbm5udX29+qrr9rbenh4VHqTcOLECfv5iIiIat/cOOK2226z93XvvffW2La4uLjCG7uPP/64wvnt27fbz9W2JKw2rgp4yp7jNWvWVNt+2bJlFdovX768QePn5ubal+mFhYVVCsrK1DXgKXvzd/jw4QbVd67aAp7rrrvOfn7ZsmVOHbsmjgQ8ZR9hYWHGunXrnDLut99+a++3ZcuWDt+vRYsW9vt99913DaqhsQMeScY//vGPavs7ePCgPciQZKxfv77Kdo0R8Hz99df29ucu8XQHH3/8sb2+hx9+uNp25y5Hff7556ttm5WVVSE8/+c//9ngOkeMGGHvb9euXVW2qe/rCwEPgPMNmywDgIscP368wsbAQUFBLq8hNzdXCxcutN9+8cUXFRgYWG37++67z37p9tLS0gpLESTZl1JJUkhISL2X3hw+fFgffPCBJKlt27Z64YUXamzv6empZ555xn57wYIF1dZ1wQUX1KsmM9x8880aMGBAteevuuoqjR8/3n77nXfeadB4gYGBGjdunCQpKyvLvgzMGaZPn67Q0FCn9ecIs77uzZo108SJEzVv3jzt2LFDx48fV2FhoQ4ePKglS5ZowoQJ9p+NrKwsXXvttUpJSWnwuGVLYCTJ19fX4fuVb1u+D3d0wQUXaPr06dWeb9Omja699lr7bVdunO3urzMTJkxQQECAJOnHH3906D5RUVF68MEHqz3ftm3bCl+POXPmyDCMBtVZftNrR+s04/UFAKyAPXgAwEVOnDhR4XbZL96utHbtWvtVmEJDQzVq1Kga23t4eOi2226z/8K/YsWKCudDQ0PVvHlznTp1Sjt27NCaNWvqta/Qjz/+aN+fZ/z48VXu9XOuyy67TP7+/srLy9Pq1asrnCu/N82KFSuUkpKi6OjoOtflao7s+TFlyhQtWrRIUuWvR1X++OMPrV+/XklJSTp69Kjy8vIqvCFLTEy0H2/ZskUXX3xxPSqvrD57oTRU+a/7f/7zH82aNcsl4x44cEAhISGVPl8WPlx77bVasmSJrr/+ep06dUpHjhzR3/72N4ffzFbn1KlT9mMfHx+H71d+r6WCgoIG1dDYRo0aVevrQe/evfXJJ59IkkNX8nKW8t9vixYt0j/+8Q+1bt3aZeNL0rZt27R582alpaXp+PHjla6yVxYsbt++XaWlpfLwqPlvuzfddJO8vGp+e/CnP/1JDzzwgEpKSpSZmank5OQq9yYrk5+fr/Xr12v79u06fPiwTpw4UWHfswMHDtiPt2zZUuPYZcx4fQEAKyDgAQAXadGiRYXbZvzlfPPmzfbjvn371vqLvKQKgc3mzZtlGIb9TYOPj4/Gjh2rjz/+WMXFxRoyZIgmTZqkCRMm6IorrnB4ltK6devsx9u2bdPdd9/t4CM6oyy4KNvENiIiQv369dP69et17NgxXXrppbrllls0btw4DRw4sMZLSZvFZrPpsssuq7Vd//797ceHDh1SVlaWwsLCKrXbtWuXHnnkES1durTKTaSr4qyNh6OiotSqVSun9FUXEydO1Ny5cyWdCXg2bdqkKVOmaPjw4Q5t3lpfVYU75xo5cqTeeOMN3XnnnZKk5cuXa9OmTbr00kvrPW754MORS02XKR8C1GXmjxkcCRzLP//lZ9U0tn79+ikiIkLp6enav3+/unXrpltvvVWjRo3SZZddVqfQra7mz5+vZ5991uGZYEVFRTp27JiCg4NrbFf+9aU6wcHBiomJsc/427x5c5UBz5EjRzR9+nS99957lf7AUR1HXoPMen0BACsg4AEAF2nZsqW8vLzsy7Ryc3NdXsPhw4ftxx07dnToPpGRkfbjwsJCnThxosJVd1577TVt2rRJe/bsUWFhod5//329//778vDwULdu3XT55Zdr6NChGjFiRLVXaSq7YpckrV69utKMHEccPXq0wlWK5syZoyFDhujQoUM6efKkZs2apVmzZsnLy0u9evXSFVdcoeHDh+vKK6+Up6dnncdztuDg4EohYFXKroZVNnvj8OHDlQKe77//XmPGjKn01/zaOPomzJEazTB8+HDdc889mjlzpiRp48aN2rhxo6Qzs2kGDRqkhIQEjR07Vu3bt3d5fdOmTdPTTz9tvwrS0qVLGxTwlJ8FWJeZOOXbmjGTsC5qWkJaxtvb235cVFTUmOVUGvf999/XyJEjdfLkSWVnZ+ull17SSy+9pObNm6tPnz664oordM0112jAgAFOuXqcYRiaNm2a3n333Trf98SJE7UGPB06dHCorw4dOtgDnvL/r5T5/fffdcUVV9i/1+tSY23ccTkcALgL9uABABcqH6o4c78TR5WfNeToJZvPbXfuL+Bt27ZVYmKiHnvsMbVp08b++dLSUm3fvl1vvvmmxo0bp7CwMD3//PNVziYpu9RxQ5Tf30iSunbtqq1bt+qee+6p8CaxuLhYiYmJevXVVzV8+HB17NhRs2fPbvD4DVWXWUXlvybnfj0OHz6sSZMm2cOdjh076rnnntPq1auVmZmp/Px8lZaWyjhzoQU9/vjj9vuWlpY28FGcYeaskDfeeEOLFi2qdOn6Q4cO6fPPP9c999yjDh06aMKECXV+89lQHh4eGjJkiP12UlJSg/o7d+ZK+SVb1cnPz6/wPePuMyGcEYo0pvj4eG3dulWTJ0+u8H1/6tQprV69Ws8++6wGDRqk2NhYLV68uMHjvfPOOxXCnauvvlrz58/X9u3bdfToUZ0+fdr+s20YRoX/cxz5+Xb0daim1yDpzFKvsp+vFi1a6IEHHtB3332n3377TSdPnlRJSYm9xvJLTR2p0d1nnQGAmQh4AMCFBg0aZD/+5ZdfXD5++b/W5+XlOXSfc9tVNcukZcuWeuqpp3TgwAGtX79eL730ksaOHVthE8yjR4/qH//4h6677rpKm3KWf7Pw6quvVniD4uhH+ZlGZdq0aaM33nhDhw4d0sqVK/XUU09pxIgRFWYgHThwQHfccYfuvfdeh56PxpKfn+9w2/Jfk3O/Hu+88449MOvZs6e2bdumv//97xo4cKDCwsLk6+tb4U2zs2btuJNx48bpl19+0e+//6758+frz3/+s7p27Wo/bxiGPv/8c11yySVO2ey4LsrPtmrokriYmJgKt3///fda73NuqHVuH43NWSGiO+nUqZPmz5+vw4cP67vvvtNjjz2mwYMHVwgiUlJSNG7cOL366qsNGuvll1+2H8+YMUNLly7V5MmT1b17dwUFBVVaFlbXn29HX4dqeg1au3at1q5dK+nM/znr16+3B+pRUVHy9/evsBdQU3wNAgCzEPAAgAuV/+v977//bv8l2FXKT213dPZC+U1LfXx8alxG5Onpqcsuu0z/8z//oy+++EKHDh3Sf//7X40ePdre5ssvv9Tnn39e4X7lZ/4cPHjQobrqolmzZoqPj9djjz2mb7/9VtnZ2Vq6dGmFwG3mzJn25TxmOHr0qEP7MmVnZ1eYqXHulWSWL19uP37ssccqhFlVcSQUsKoOHTpo8uTJ+s9//qOdO3dq//79mjFjhn2WQk5Ojv7f//t/Lq2p/BtjR2fRVScwMLBCYFR+j63q/Prrr/bjdu3a1fr9UZvyy6POnUVXFWfM1nNX/v7+Gj58uJ566in99NNPysnJ0aefflphH6F//OMfFTYVrov09HTt2bNH0pmrMP7jH/+osf3x48d19OjROo3h6P8L6enp9uOaXoOmTJlSIVytSlN+DQIAVyPgAQAXuv766yv8MtzQv+bWVe/eve3HGzZscGjz3fIhVO/eveu0ZMLDw0ODBg3S4sWLNXToUPvnv/rqqwrtym8uvGbNGof7ry9vb29dffXV+vHHH9W9e3f757/++utKbV21RMQwDIdmdZXfkLpNmzYKDw+vcL78fka1bVBbUlLikufbXURERGj69Ol6++237Z/74Ycf6rxXUUOUD2HO/drVx+DBg+3HK1eurLX9qlWr7MflA+f6Kh8Q5eTk1Np++/btDR6zsTj7Z93X11cTJkzQypUr7SF2YWGhvv/++3r1V/5nOzY2tkK4VpXVq1fX+RLm69evr7VNbm6udu/ebb99ySWXVFunI5tk//zzz3WosG7cfYkfADgbAQ8AuJCvr2+FpUCff/55pdksjsjLy6vX7J8BAwbYNzo+fPiwvvnmmxrbl5aWVtjvob5vCG02W4VLsh86dKjC+eHDh9uv6LV27Vpt3bq1XuPUVbNmzTRs2LBq65IqXqmosTdwff/992tt895779mPy7+5L1N+6UNtyy0WL17cKDOm3F35GWVFRUU6cuSIS8bdvXt3hZ/bhISEBvc5duxY+/HChQtr3Gy5oKDAfjnxc+9bX+WXRtZ2ievExESlpqY2eMzG0lg/661atapwNcKqXmccUZefbUmaNWtWncf46KOPag3+FyxYYG8TFhZWaZlfXerMzMzUl19+Wec6HeXK128AcAcEPADgYg8//HCFv3jecsstVc4cqc6OHTvUr18//fDDD3UeOygoSJMmTbLffuihh2rc/+Df//63/S/uHh4e9ks8lzlx4oTDl2cuP6W/devWFc61a9dOf/rTnySdmckyefJkhy93XFpaWukqLkePHnV4r4+a6pIqbmRb36UVjvrggw9qnMWzYsWKCoHg7bffXqlNp06d7MfnzpQq7/Dhw3rggQfqWal7cnRPm/Jfcw8PD4cuc14dR5bVSWfe6E6dOtX+xjg0NFRXX311vcctM3r0aPsVwXJzc/XMM89U2/app56yX72vY8eOGjlyZIPHLz/7bv78+dW2Ky4u1n333dfg8RpTUFCQPZw4fPhwrYGAIzOWytT2OuOIqKgo+4yUHTt26Lfffqu27cKFC7VkyZI6j7Fv3z699tpr1Z4/dOiQnnzySfvtadOmVZol4+hrUElJie68806H/w+pD1e+fgOAOyDgAQAXa9asmT799FP7L/kFBQUaO3asJk+eXO1VdQzD0MaNGzVlyhT17NlTO3bsqPf406dPt2+2nJKSouHDh1d6o1BaWqp//etfFfYnueuuuyptZLxp0yZFRkbqiSeeqPaqYCUlJVq4cKH90tWSNGLEiErtnnnmGft+Itu2bVPfvn1rDLEyMjL02muvKSYmRgsXLqxw7ssvv1R0dLRefvnlCnsIlXf69Gn9+9//1meffVZjXeWXcH355ZeN9mbE29tbJSUlGjlypH788cdK57/55huNGzfOvuRi6NChuvLKKyu1Kz9T6rnnntMHH3xQqc2vv/6q+Ph4paenN3gfGHfSv39/3XTTTVq6dGm1X6eUlBRNmTLFfvvKK6+stDFtXURGRmr69OkVlqyca82aNerfv3+F8O6pp56q8RLlCQkJstlsstlsNc70adasmWbMmGG//dxzz+mNN96oEHCWlpbqjTfe0AsvvGD/3JNPPtmgx11m0qRJ9lBk3bp1+vvf/15pBkhGRoZGjhyptWvX2mcQuqNmzZqpc+fOks7M9qjtqlczZ85Ur169NGvWrGpnwp08eVKPPvqofX8vT0/PCrMG6yI0NFT9+vWTdOZrOmHCBCUnJ1doU1paqv/7v//TLbfcIk9PzwozWBzh4+OjRx55RP/6178qheRJSUkaOnSo/vjjD0lnlohWFRJfe+219tBn5cqV+p//+Z9KM8sOHjyo6667Tt98802jvgaVf/3+5ZdfHN5jKDIy0v7zN3Xq1EaqDgCcz8vsAgDgfNSpUyf98ssvGjVqlHbs2KHS0lK9//77ev/99xUZGakePXooNDRUJSUlOnjwoLZs2VJpWn9Nmx3X5MILL9Ts2bN18803q6SkROvWrVNMTIwuv/xyXXjhhTp58qT++9//VvhrZ79+/fTiiy9W2V9WVpZmzJihGTNmqG3bturVq5fatm0rLy8vHTp0SJs2baqwJ8Pll1+uG264oVI/4eHh+vLLL3XNNdcoOztbycnJGj58uNq1a6e+ffvqggsuUFFRkbKzs7Vjx45al3rs27dPDz30kB566CF16NBBPXr0sIdqBw8e1Pr16ysszbn55ps1YMCASv2MGDFCvr6+Kigo0JYtW9SlSxclJCQoKCjI/iZm2LBh9X7TVv7xjxs3Tq+//rqGDh2qnj17qlevXjIMQ5s2bdLOnTvtbcPCwvTOO+9U2c+UKVP0yiuvKCUlRadPn9Ytt9yiZ599Vj179lTz5s21Y8cOJSYmSjpzla3hw4dX+7W1mqKiIn300Uf66KOP5Ovrqx49eqhTp05q2bKljh49qt9++83+2KUzSybLX5WoPnJycvTUU0/pqaeeUnh4uHr06KE2bdqoefPmOnLkiDZt2lQpQL3rrrv0l7/8pUHjlnfbbbdp5cqVev/991VaWqr77rtPb7zxhj0MWL9+vfbt22dvf+utt2ry5MlOGbtjx476y1/+ojfffFOS9MILL+ijjz7SFVdcoebNm2vfvn1as2aNCgsLddVVV6lt27ZVho7u4rrrrtOzzz4r6cxrwrx583TRRRdV2O+m/PfM1q1b9be//U133XWXLrzwQnXv3l2hoaEqKipSVlaW1q5dW2GW19///ndFRETUu76nnnpKw4YNU2lpqTZv3qyLL75YAwcOVKdOneyv3VlZWZLOhOZvv/12nTYxfvHFF3X//ffr/vvv18svv6xBgwYpICBAKSkpWr16tT308fLy0ty5c9WqVatKfcTGxuqWW26xLyd95ZVX9OGHHyouLk6tW7dWWlqafv75ZxUWFqpFixZ66aWXnPrzUF7btm01YMAArV27VqdOnVLPnj119dVXKywszB5MXnjhhfrrX//aKOMDgMsZAADTnDhxwnjyySeNoKAgQ5JDHz179jS++OKLKvubMmWKvd27775b49hff/210aZNm1rHu/HGG428vLwq+1i/fr3h5eXlcO0TJkwwjh8/XmNdaWlpxpVXXulwn23atDG+++67Cn18+umnhs1mc+j+Hh4ext/+9jejsLCw2ppmzZpVY3+PP/54jY+pOqmpqfY+OnbsaBQWFhrTpk2rsd6YmBgjKSmpxn6Tk5ONTp061djPwIEDjYyMDOPxxx+v9XG8++679jZTpkypss2KFSvsbeLj4+v1fNQmPj7ePsaKFSsqne/evbvD3zdRUVHGmjVrGlyTo+NJMoKDg4133nmnzo/Vkefz9OnTxt13313j96nNZjPuvffeGr/X66OgoMC45ppranzsI0eONI4ePerQa1RdXscMw7HvT0faGIZh5ObmGrGxsTU+ljIvv/yyw197Hx8fY8aMGbU+FkfMmjWrxtddDw8PY/r06UZpaanRsWNH++dTU1Or7O/cNrNmzTJ8fHyq7T8oKMhYtGhRjTXm5eUZw4YNq/E5ad++vbF69WqHXjsa8vqyceNGo0WLFtXWUVV/5Z+Tmr5fAMDdMIMHAEwUEBCgf/7zn7r33nv17bffatmyZdq0aZP++OMPHTlyRD4+PmrVqpViY2N12WWXaezYsZWuWFJfI0eO1N69ezV37lwtWbJEO3fuVHZ2tnx9fRUeHq7Bgwdr8uTJFfbYONdll12mP/74Qz/++KNWr16tzZs3a9++fcrJyVFJSYlatmypCy+8UP369dOf/vQn9e3bt9a6OnbsqB9//FHr1q3Tp59+qp9//lnp6ek6evSovLy8FBISos6dO6tPnz4aNmyYEhIS7Bs0l5kwYYKysrL0ww8/aM2aNdq6dat+++03+/4jgYGBio6O1qBBgzR58uRaL+P7l7/8RRdffLHeeust/fLLLzpw4IDy8/PrfIWa2nh7e2v27Nm6/vrrNWfOHG3cuFFZWVny9/dXly5dNGnSJN155521LnOJjo7W5s2b9X//939atGiRkpOTVVhYqLZt2+riiy/WTTfdpIkTJ8rT09Op9Ztty5YtWr9+vVasWKENGzYoOTlZmZmZys/Pl5+fn32G2ejRozVx4kSnLBdKSUnRunXrtG7dOm3dulWHDx9Wdna2Tp48qYCAALVu3VqXXnqprrrqKt1www32S7Q7m4+Pj2bOnKlbbrlFc+fO1cqVK+2z8Nq1a6eEhARNmzZNcXFxTh+7efPmWrJkiT766CPNnz9fv/76q44dO6bWrVurZ8+emjp1qiZMmGCJKxoFBgZq48aNevPNN/XNN98oKSlJubm5Ve7H8+CDD+q6667TsmXLtHbtWm3fvl1paWk6fvy4PDw8FBQUpC5dumjIkCGaPHmyOnbs6JQa//KXv2jgwIF67bXXtGLFCmVmZsrX11ft2rXTkCFDdNttt1W4YmJ9+r/88sv1n//8Rz/++KMyMjIknVm2NGrUKN1zzz325bTV8fPz09KlS/Xhhx9q/vz52rx5s44fP67Q0FB16tRJ1113naZOnarg4GCHrv7WEH369NG2bds0c+ZMrVixQr/99ptOnjzp0FUkAcBqbIazfzsFAAAOSUtLU1RUlKQzwVZ1+wUBQGOJjIy0L+NKTU2ttNcaAMA62GQZAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsrlEDnsTERD355JMaNmyY2rdvr2bNmikgIEDR0dG69dZbtXr16jr1t3TpUo0bN87eV/v27TVu3DgtXbrUqXXn5+frxRdfVFxcnFq1aiV/f3/FxsbqwQcftF9GEgCAhoqMjJRhGDIMg0ukAzBFWlqa/XWIS6QDgLXZDMMwGqPjK664Qv/9739rbTd58mS988478vHxqbZNaWmp7rzzTs2ZM6faNrfffrveeusteXg0LLPau3evrrnmGu3Zs6fK8y1bttSCBQs0cuTIBo0DAAAAAADgLI02gyczM1OSFB4ervvuu0+fffaZNmzYoHXr1unVV19Vu3btJEnvvfeepk6dWmNfjz76qD3c6d27tz766CNt2LBBH330kXr37i1Jmj17th577LEG1XzixAlde+219nDnjjvu0PLly7V27Vo988wzCggI0PHjxzVp0iRt2bKlQWMBAAAAAAA4S6PN4Bk5cqQmT56s6667Tp6enpXOZ2dna+DAgUpJSZEkrVq1SldccUWldikpKerWrZuKi4vVp08f/fzzz/L19bWfz8/PV3x8vBITE+Xl5aWkpCRddNFF9ap5+vTpeuqppyRJL774oh566KEK59euXav4+HgVFxcrPj5eK1eurNc4AAAAAAAAztRoM3iWLFmiiRMnVhnuSFJoaKheeeUV++3PPvusynavv/66iouLJUkzZ86sEO5Ikp+fn2bOnClJKi4u1muvvVaveouKivTGG29Ikrp06aIHH3ywUpsBAwZo2rRpks4EUhs3bqzXWAAAAAAAAM5k6lW0Bg8ebD/et29fpfOGYejLL7+UJMXGxqpfv35V9tOvXz/FxMRIkr788kvVZ1LSihUrdOzYMUnSlClTqt3Lp/xysi+++KLO4wAAAAAAADibqQHP6dOn7cdVzfRJTU217+UTHx9fY19l5w8cOFCvK5GUv6JXTWP16dNHfn5+kqQ1a9bUeRwAAAAAAABn8zJz8FWrVtmPu3TpUun8rl277MexsbE19lX+fFJSkqKioupUi6NjeXl56aKLLtK2bduUlJRUpzEyMjJqPH/q1Cnt3r1bbdq00QUXXCAvL1O/PAAAAAAANEnFxcU6fPiwJOniiy9W8+bNTa6o4UxLEEpLS/X888/bb0+cOLFSm/KBSPv27WvsLyIiwn6cnp5e53rKxvL391dQUFCtY23btk2HDx/W6dOn1axZM4fGKF8jAAAAAAAw34YNGxQXF2d2GQ1m2hKt1157TRs2bJAkjR8/XpdeemmlNidOnLAfBwQE1Nifv7+//fjkyZN1rqdsrNrGccZYAAAAAAAAzmTKDJ5Vq1bp73//uySpdevWmjVrVpXtTp06ZT/28fGpsc/ys2gKCgrqXFPZWLWN05CxaptZlJ6ergEDBkg6kyCGhYU53DcAAAAAAHBMVlaW+vbtK0m64IILTK7GOVwe8OzcuVPjxo1TcXGxmjdvrk8//VStW7eusm35NXCFhYU19lt+w+ZzL6XuiLKxahunIWPVtsysvLCwsDq1BwAAAAAAdddU9r916RKt1NRUDRs2TEePHpWnp6c+/vhjXXHFFdW2b9Gihf24tqVQeXl59mNHlllVN5YjS64aOhYAAAAAAIAzuSzgyczM1FVXXaXMzEzZbDbNnTtXY8aMqfE+5Wew1HYFqvLLn+qzmXHZWHl5ecrNzXVorAsuuMDhDZYBAAAAAAAai0sCnuzsbA0dOlS//fabJGnmzJmaPHlyrffr2rWr/Xj37t01ti1/vqpLrjtrrOLiYu3bt6/e4wAAAAAAADhbowc8x44d0/Dhw7Vr1y5J0vPPP6+77rrLoftGRUUpPDxc0pmNmWvy888/S5LatWunyMjIOtc5aNAg+3FNYyUmJtqXaA0cOLDO4wAAAAAAADhbowY8+fn5uvbaa/Xrr79Kkh599FE98sgjDt/fZrPZl3Ht3r1b69evr7Ld+vXr7bNuxowZI5vNVudaExISFBgYKEmaP3++DMOost28efPsx+PGjavzOAAAAAAAAM7WaAFPYWGhxo0bpzVr1kiS7rvvPj399NN17uf++++Xp6enJOmee+6pdFnygoIC3XPPPZLO7Hx9//33V9nP1KlTZbPZZLPZtHLlykrnfXx8dO+990qSkpKS9PLLL1dqs27dOs2ZM0eSFB8fr7i4uDo/HgAAAAAAAGdrtGuB3Xjjjfrhhx8kSUOGDNG0adO0Y8eOatv7+PgoOjq60uejo6P10EMP6fnnn1diYqIGDhyoRx55RBdeeKH27dunF154QZs3b5YkPfTQQ+rcuXO9a37ooYe0cOFCpaSk6OGHH9bevXt1ww03yNfXVytWrNCzzz6r4uJi+fr66vXXX6/3OAAAAAAAAM5kM6pbi9TQjuu4TKpjx45KS0ur8lxpaanuuOMOzZ07t9r7T5s2TW+//bY8PKqelDR16lTNnz9fkrRixQolJCRU2W7v3r265pprtGfPnirPt2zZUgsWLNDIkSOrfzD1lJGRYb8CWHp6eoWriAEAAAAAAOdoiu+/XXaZ9Ibw8PDQnDlz9M0332jMmDEKDw+Xj4+PwsPDNWbMGH377beaPXt2teFOXVx00UXavHmzXnjhBfXp00dBQUHy8/NTTEyMHnjgAW3btq1Rwh0AAAAAAID6arQZPKi7ppggAgAAAADgbpri+29LzOABAAAAAABA9Qh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALM7L7AIAAO7HMAzl5ucrLSdHaTlHlJaToyN5eSoqLlFRSYmKS0vl5eEhb09PeXt5qpW/vyJDQhQZ0kqRoaEK9vMz+yEAAAAA5xUCHgCAJCkz95g2pKYqNTtHqTnZOl5wyuH7ph85qq3pGfbbgb6+igwJUVRoiPpGRSk8KLAxSgYAAABwFgEPAJzHiktLtXn/fv2UlKykgwed1u+xggJtzcjQ1owMLd6yVV3C2mpIbKx6d4iQlwergwEAAABnI+ABgPPQ0bw8rUzZo1XJKcotKGj08ZKyDiop66CC/HyVEB2t+JholnEBAAAATkTAAwDnkYLCQn2SuEmrUvao1DBcPn5ufoEWb9mqr7ZuU3x0Z02M6yNfb2+X1wEAAAA0NQQ8AHCe2JmZqbmr1yonL8/sUlRqGFqRnKJtGQd026AB6hYebnZJAAAAgKUR8ABAE1dQWKiFGzdpZUqK2aVUkpOXp5e+X6aEmGhNYjYPAAAAUG8EPADQhLnTrJ2arExO0XZm8wAAAAD1xqVMAKCJWrpjp176fpnbhztlymbzLN2x0+xSAAAAAMthBg8ANDGGYWjRr5v19bbtZpdSLws3Jiq/sFDje/eSzWYzuxwAAADAEpjBAwBNiGEY+nDDRsuGO2W+3rpNH27YKMOEK30BAAAAVkTAAwBNyKJfN2vZriSzy3CKZbuStGjzFrPLAAAAACyBgAcAmoilO3ZafubOub7euo09eQAAAAAHEPAAQBOwMzNTCzcmml1Go1i4MVG7MrPMLgMAAABwawQ8AGBxBYWFmrt6rdllNKo5a9aooKjI7DIAAAAAt0XAAwAWtzBxk2UuhV5fOSfz9EkTnaEEAAAAOAMBDwBY2M7MTK1MTjG7DJdYkZzCUi0AAACgGgQ8AGBR58PSrHOxVAsAAACoGgEPAFjUJ+fB0qxz5ZzM06eJm8wuAwAAAHA7BDwAYEFH8/O1KmWP2WWYYlVyio7m55tdBgAAAOBWCHgAwIJWJaeo1DDMLsMUJYahn8/TcAsAAACoDgEPAFhMcWmpVqacHxsrV2dFcrKKS0vNLgMAAABwGwQ8AGAxm/enKze/wOwyTJWbX6At+9PNLgMAAABwGwQ8AGAxP+3ebXYJbuGn3clmlwAAAAC4DQIeALCQzNxcJWUdNLsMt7ArK0uZucfMLgMAAABwCwQ8AGAhG1LTTB2/sKBAuQcO6PBvvyn3wAEVFpi7VGxDaqqp4wMAAADuwsvsAgAAjkvNznH5mIZh6ODu3Ur+abn2b/5VRrnNjW0eHupwySWKGXyl2sbGymazubS21BzXPx8AAACAOyLgAQCLMAxDaS4ONHJ+T9Pq2e8o98CBqmsqLdXviYn6PTFRQe3aadDtdyikY6TL6vvdhMALAAAAcEcs0QIAi8jNz9cxFy6Jyty5Q989/1yFcKeNpFsk3X323zbl6ztwQN89/5wyd+5wWY25BQU6mp/vsvEAAAAAd0XAAwAW4crZOzm/p2nFv2eq+PRpSVJvSQsl7Zf0nqSZZ//dL+njs+clqfj0aa3490zl/J7mslrTmMUDAAAAEPAAgFWk5RxxyTiGYWj17Hfs4c5YSWslTZTkc05bH0mTzp4fc/ZzxadPa/Xs2TIMwyX1unrZGgAAAOCOCHgAwCJcFWQc3L3bviyrt6SPJDWv5T7NVXEmT+6BDB1K3t1oNZZHwAMAAAAQ8ACAZRzJy3PJOMkrltuPH1Ht4U6Z5pIeLnd7908/ObGq6rnqeQEAAADcGQEPAFhEUXFJo49RWFCg/b/+KunMBsrj6nj/8ZJanz3e/+smFbpgU+iiksZ/XgAAAAB3R8ADABbhiiAj/8gRGaWlkqRhqrznTm18JA0/e2yUlir/6FEnVlc1Ah4AAACAgAcALKP4bPDSmIrObqwsSYH17KNl+f5OnWpQPY4oLmn85wUAAABwdwQ8AGARXh6N/5Lt3ayZ/fhYPfs4Xr6/5o7u4FN/Xp78VwYAAADwWzEAWIS3p2ejj+HXqpVsZ4OkHyQV1vH+hZK+P3ts8/SUX3CwE6urmiueFwAAAMDdEfAAgEV4ezV+kOHj66sOl1wiSTok6Ys63n+RpD/OHnfofYl8fH2dWF3VCHgAAAAAAh4AsIxW/v4uGSdm8JX24xckObqLToGkF8vdjh0yxIlVVc9VzwsAAADgzgh4AMAiIkNCXDJO29hYBbVrJ0naLOkG1R7ynJJ049n2khTUrr3axMQ2Wo3luep5AQAAANwZAQ8AWERkSCuXjGOz2TTo9jvkdXbD5S8lDZC0UJX35CmU9PHZ81+e/ZxXs2YadPvtstlsLqmXgAcAAAAg4AEAy3BlkBHSMVKD777HHvKUzeTpIGmypLvP/huhijN3vJo10+C771FIx0iX1RoZSsADAAAAeJldAADAMUF+fgr09dWxggKXjBferbuu/vs/tHr2O8o9cEDSmY2X36+uvnbtNej2210a7gT5+irYz89l4wEAAADuqlFn8Pzxxx9asmSJpk+frhEjRig0NFQ2m002m01Tp06t9f5paWn29o5+REZG1rveyMjIRh8DAOrLZrO5fDlSSMdIjX7yaQ1/+BF17NPHfgl1e02enurYJ07DH35Eo598yqXhjiR1ZPYOAAAAIKmRZ/C0adOmMbuvUkxMjMvHBABXiQoN0daMDJeOabPZ1Da2i9rGdlFhQYHyjx5V0alT8m7eXH7BwS65FHp1oth/BwAAAJDkwiVaHTp0UGxsrH744QeH79OuXTtt37691nbPPfecPvzwQ0nSlClT6l1jmTFjxujpp5+u9ryPj0+DxwCA+ugbFaXFW7aaNr6Pr6+pgc65LusUZXYJAAAAgFto1IBn+vTpiouLU1xcnNq0aaO0tDRFRTn+y7i3t7e6d+9eY5uSkhKtXLlSktSiRQuNGzeuISVLkoKCgmodFwDMEB4UqC5hbZWUddDsUkzXNSxMYYGBZpcBAAAAuIVGDXhmzJjRmN1Lkn788UdlZmZKkiZMmCBfN/rLMgA0hiGxsQQ8kobEsiQXAAAAKGP5y6S/99579mNnLM8CAHfXu0OEgvzO7zA7yM9XvTtEmF0GAAAA4DYsHfCcOHFCixcvlnTmClhXXHGFuQUBgAt4eXgoITra7DJMNTgmRp4elv4vDAAAAHAqS/92/Nlnnyk/P1+SdMstt8hmszml359//lm9evVSixYt5Ofnp6ioKE2aNEmLFy+WYRhOGQMAGiI+JloeTnrNsxpPm01XRHc2uwwAAADArbjsKlqNofzyrMmTJzut39TU1Aq309LSlJaWpk8++UQDBw7UwoUL1a5duzr3m1HLpY2zsrLq3CeA81Own5/ioztrRXKK2aW4XHxMtIL9/MwuAwAAAHArlg149u/fr1WrVkmSBgwYoIsuuqjBffr4+Gj06NEaNmyYunfvrsDAQOXm5mrdunWaNWuW0tPTtWbNGg0dOlTr1q1TYB2v3hIRwX4RAJxnYp9LtS3jgHLy8swuxWVCAvx1fZ9LzS4DAAAAcDuWDXg++OAD+3IpZ83e2bBhg4KCgip9PiEhQXfffbcmTJigH374QUlJSZoxY4ZeffVVp4wLAPXh6+Oj2wYN0EvfLzO7FJeZNnCgfL29zS4DAAAAcDuW3YPn/ffflyQ1a9ZMkyZNckqfVYU7ZVq0aKFPPvlErVq1kiS9/fbbKiwsrFP/6enpNX5s2LChIeUDOA91Cw9XQsz5seHy4JhodQ0PM7sMAAAAwC1ZcgbPhg0btHv3bknS6NGjawxmnCkwMFA33HCD3nzzTeXl5SkxMVEDBgxw+P7t27dvxOoAnK8m9blU25v4Uq2QAH9NjOtjdhkAAACA27LkDJ7G2lzZEV27drUfHzhwwKVjA0BVypZqNWUszQIAAABqZrmAp6ioSB9//LEkqXXr1rr66qtdOr6zLsUOAM7ULTxck5roDJcb4vqwNAsAAACoheUCnm+++UY5OTmSpJtuukleXq5dZbZr1y77cXh4uEvHBoCajOjeTaN6XGx2GU41qmcPXd29m9llAAAAAG7PcgFP+eVZU6ZMcenYx44ds88e8vPzU58+TfOv5QCsa/wlvTW0axezy3CKoV27aHzvXmaXAQAAAFiCpQKeI0eO6JtvvpEkXXzxxerVq5fD901ISJDNZpPNZlNaWlql8999950KCgqqvf/Jkyc1ceJE++yhadOmqVmzZnWqHwAam81m00194zSqZw+zS2mQ0T176Ka+cSyLBQAAABzUqOubVq9erb1799pvZ2dn24/37t2refPmVWg/derUGvv7+OOP7Zcmd/bsneeff14333yzxo8fr0GDBunCCy9UQECAjh07prVr1+o///mP9u/fL0mKiYnRE0884dTxAcBZbDabrrukt/x8fLRwY6LZ5dTZpLg+GsGyLAAAAKBOGjXgmT17tubPn1/luTVr1mjNmjUVPldbwFO2PMvT01M333yzU2os78iRI5o9e7Zmz55dbZv4+HgtWLBArVq1cvr4AOBMI7p3U8dWrTRn9RpLXEI9JMBf0wYOZENlAAAAoB5cu0NxA+zZs0e//PKLJGno0KFq27atU/t/+eWXtXz5cq1bt07JycnKzs5Wbm6u/Pz8FB4erssuu0w33nijhg0bxpIBAJbRNTxMT48bo4UbE7UyOcXscqo1OCZaE+P6cCl0AAAAoJ5shmEYZheBMzIyMhQRESFJSk9PV/v27U2uCEBTsjMzU3NXr3Wr2TzM2gEAAIAZmuL7b0ttsgwAqL9u4eF6etwYDYmNkYfJMxE9bTYNiY3R02PHEO4AAAAATmCZJVoAgIbz9fbW5P79NKpnD61KTtHKlBTl5ld/BUFnC/Lz1eCYGF0R3VnBfn4uGxcAAABo6gh4AOA8FOznp7G9e2lkzx7avD9dP+3eraSsg402XtewMA2JjVGvDhHy8mDyKAAAAOBsBDwAcB7z8vBQXGRHxUV2VGbuMW1ITVVqTo7SsnN0rKD+M3uCfH3VMTREUSEh6hsVpfCgQCdWDQAAAOBcBDwAAElSeFCgxvbuZb99ND9fadk5Sss583EkL09FJSUqKilRcUmpvDw95O3pKW9PT7Xy91dkSMiZj9AQll8BAAAALkbAAwCoUrCfn4I7+Kl3hwizSwEAAABQCzZCAAAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4L7MLAMxmGIZy8/OVlpOjtJwjSsvJ0ZG8PBUVl6iopETFpaXy8vCQt6envL081crfX5EhIYoMaaXI0FAF+/mZ/RAAAAAAAOc5Ah6clzJzj2lDaqpSs3OUmpOt4wWnHL5v+pGj2pqeYb8d6OuryJAQRYWGqG9UlMKDAhujZAAAAAAAqkXAg/NGcWmpNu/fr5+SkpV08KDT+j1WUKCtGRnampGhxVu2qktYWw2JjVXvDhHy8mAVJAAAAACg8RHwoMk7mpenlSl7tCo5RbkFBY0+XlLWQSVlHVSQn68SoqMVHxPNMi4AAAAAQKMi4EGTVVBYqE8SN2lVyh6VGobLx8/NL9DiLVv11dZtio/urIlxfeTr7e3yOgAAAAAATR8BD5qknZmZmrt6rXLy8swuRaWGoRXJKdqWcUC3DRqgbuHhZpcEAAAAAGhiCHjQpBQUFmrhxk1amZJidimV5OTl6aXvlykhJlqTmM0DAAAAAHAiAh40Ge40a6cmK5NTtJ3ZPAAAAAAAJ+ISP2gSlu7YqZe+X+b24U6Zstk8S3fsNLsUAAAAAEATwAweWJphGFr062Z9vW272aXUy8KNicovLNT43r1ks9nMLgcAAAAAYFHM4IFlGYahDzdstGy4U+brrdv04YaNMky40hcAAAAAoGkg4IFlLfp1s5btSjK7DKdYtitJizZvMbsMAAAAAIBFEfDAkpbu2Gn5mTvn+nrrNvbkAQAAAADUCwEPLGdnZqYWbkw0u4xGsXBjonZlZpldBgAAAADAYgh4YCkFhYWau3qt2WU0qjlr1qigqMjsMgAAAAAAFkLAA0tZmLjJMpdCr6+ck3n6pInOUAIAAAAANA4CHljGzsxMrUxOMbsMl1iRnMJSLQAAAACAwwh4YAnnw9Ksc7FUCwAAAADgKAIeWMIn58HSrHPlnMzTp4mbzC4DAAAAAGABBDxwe0fz87UqZY/ZZZhiVXKKjubnm10GAAAAAMDNEfDA7a1KTlGpYZhdhilKDEM/n6fhFgAAAADAcQQ8cGvFpaVamXJ+bKxcnRXJySouLTW7DAAAAACAGyPggVvbvD9dufkFZpdhqtz8Am3Zn252GQAAAAAAN0bAA7f20+7dZpfgFn7anWx2CQAAAAAAN0bAA7eVmZurpKyDZpfhFnZlZSkz95jZZQAAAAAA3FSjBjx//PGHlixZounTp2vEiBEKDQ2VzWaTzWbT1KlTHepj3rx59vvU9jFv3jyn1J2dna3p06erR48eatmypVq2bKkePXpo+vTpysnJccoYqN2G1DRTxy8sKFDugQM6/Ntvyj1wQIUF5i4V25Caaur4AAAAAAD35dWYnbdp06Yxu28Uv/zyi8aOHauDByvOHNm+fbu2b9+u2bNna/Hixerbt69JFZ4/UrNdH6YZhqGDu3cr+afl2r/5VxnlNje2eXiowyWXKGbwlWobGyubzebS2lIJFwEAAAAA1WjUgKe8Dh06KDY2Vj/88EO9+/j+++8VHh5e7fn27dvXu29JSk9P16hRo3T48GF5eXnp//2//6eRI0dKkpYsWaJXX31VWVlZGjVqlDZt2tTg8VA9wzCU5uJAI+f3NK2e/Y5yDxyouqbSUv2emKjfExMV1K6dBt1+h0I6Rrqsvt9NCLwAAAAAANbQqAHP9OnTFRcXp7i4OLVp00ZpaWmKioqqd3/R0dGKjIx0XoHnePTRR3X48GFJ0ocffqjrr7/efu7yyy/XpZdeqkmTJumPP/7QY4895rQlYagsNz9fx1y4JCpz5w6t+PdMFZ8+bf9cG0nDJAVKOibpB0mHyuo7cEDfPf+cBt99j8K7dXdJjbkFBTqan69gPz+XjAcAAAAAsI5G3YNnxowZGjlypCWWah08eFALFiyQJA0fPrxCuFNm4sSJGj58uCTp/fffr7SMC87jytk7Ob+nVQh3ektaKGm/pPckzTz7735JH589L0nFp09rxb9nKuf3NJfVmsYsHgAAAABAFbiK1llfffWVSs/ut3LrrbdW265sc+jS0lJ99dVXrijtvJSWc8Ql4xiGodWz37GHO2MlrZU0UZLPOW19JE06e37M2c8Vnz6t1bNnyzAMl9Tr6mVrAAAAAABrIOA5a/Xq1fbj+Pj4atuVP7dmzZpGrel85qog4+Du3fY9d3pL+khS81ru01wVZ/LkHsjQoeTdjVZjeQQ8AAAAAICqWCrgufXWWxUeHi4fHx+FhoaqX79+euyxx3Sgmk1x62LXrl2SpMDAQLVt27badmFhYWrZsqUkKSkpqcHjompH8vJcMk7yiuX240dUe7hTprmkh8vd3v3TT06sqnquel4AAAAAANbisqtoOcPKlSvtxzk5OcrJydEvv/yiV155Ra+//rr+/Oc/17vvjIwMSY5diSsiIkI7d+5Uenp6vcaoTlZWVp36a8qKiksafYzCggLt//VXSWc2VB5Xx/uPl9Ra0h+S9v+6SYUFBfLx9XVukecoKmn85wUAAAAAYD2WCHg6deqk8ePHq3///oqIiJAk/fbbb/r888/12Wef6dSpU/rLX/4im82mO++8s15jnDhxQpIUEBBQa1t/f39J0smTJ+s0RlntqJ0rgoz8I0dknN13aZgq77lTGx9JwyW9rzOXUM8/epSABwAAAABgCrcPeMaNG6cpU6bIZrNV+HxcXJwmTZqkJUuWaPz48SoqKtIDDzyg0aNH17jEqjqnTp2SJPn41P42v1mzZpKkAhdexvt8U3w2eGlMReUuiR5Yzz5alu/v7PdQYyouafznBQAAAABgPW6/B09gYGClcKe8kSNHavr06ZKk/Px8zZkzp17jNG9+ZveVwsLCWtuePhsM+NZxtkZ6enqNHxs2bKh74U2Ul0fjf2t6nw3qJOlYPfs4Xr6/5o7u4FN/Xp5u/yMLAAAAADBBk3i3eOedd9pDoFWrVtWrjxYtWkhybNlV3tmNbh1ZzlVe+/bta/wICwure+FNlLenZ6OP4deqlWxng6QfJNUe7VVUKOn7s8c2T0/5BQc7sbqqueJ5AQAAAABYT5MIeFq3bq2QkBBJqvcVtco2V65tI2RJ9s2V2VOn8Xh7NX6Q4ePrqw6XXCJJOiTpizref5HObLAsSR16X9Lo++9IBDwAAAAAgKo1iYBHUo3LuBzRtWtXSdKxY8d08ODBattlZWXp+PEzC3O6dOnSoDFRvVZnN7JubDGDr7QfvyDJ0V10CiS9WO527JAhTqyqeq56XgAAAAAA1tIkAp7Dhw8rOztbkhQeHl6vPgYNGmQ/rmmZV/lzAwcOrNdYqF3k2RlZja1tbKyC2rWTJG2WdINqD3lOSbrxbHtJCmrXXm1iYhutxvJc9bwAAAAAAKylSQQ8b7/9tgzDkCTFx8fXq4/Ro0fL4+x+LO+++2617ebNmydJ8vDw0OjRo+s1FmoXGdLKJePYbDYNuv0OeZ3dcPlLSQMkLVTlPXkKJX189vyXZz/n1ayZBt1+e4NnkDmKgAcAAAAAUBW3DnjS0tK0efPmGtssWbJETz75pKQzV7W69dZbq2yXkJAgm80mm82mtLS0Sufbtm2rm2++WZL0/fff67PPPqvU5tNPP9X335/ZVveWW26p1+XY4RhXBhkhHSM1+O577CFP2UyeDpImS7r77L8Rqjhzx6tZMw2++x6FdIx0Wa2RoQQ8AAAAAIDKvBqz89WrV2vv3r3222XLqCRp79699tkwZaZOnVrhdlpamgYPHqz+/ftr1KhR6tmzp1q3bi1J+u233/TZZ5/ps88+s8/eefnll9Xu7HKb+njmmWf03Xff6fDhw7rxxhuVmJiokSNHSjoTJL3yyiuSpAsuuEBPP/10vcdB7YL8/BTo66tjBQUuGS+8W3dd/fd/aPXsd5R7dqPuQ5Ler66+du016PbbXRruBPn6KtjPz2XjAQAAAACsw2aUpSONYOrUqZo/f77D7c8tZeXKlRo8eHCt9/Pz89Nrr72mO++8s9o2CQkJ9v1zUlNTFRkZWWW7X375RWPHjq12o+W2bdtq8eLFuuyyy2qtq64yMjLsV+ZKT0+3X9nrfPXasuXa6sBVzZzJMAwdSt6t3T8t1/5ff5VRWmo/Z/P0VIfelyh2yBC1iYl12bKsMj0j2uuBq66svSEAAAAAoEZN8f13o87gaahLL71UH3zwgdatW6fExERlZWUpOztbxcXFCg4OVrdu3XTllVfq9ttvt8/saajLLrtM27dv17/+9S8tXrzYvpwrKipKY8aM0f3332+/JDsaV1RoiMsDHpvNpraxXdQ2tosKCwqUf/Soik6dknfz5vILDnbJpdCrE8X3HQAAAACgGo06gwd10xQTxIbIzD2m//1isdlluI3nxo9VWGCg2WUAAAAAgOU1xfffbr3JMs5v4UGB6hLGRtaS1DUsjHAHAAAAAFAtAh64tSGxsWaX4BaGxMaYXQIAAAAAwI0R8MCt9e4QoSA/8/a9cQdBfr7q3SHC7DIAAAAAAG6MgAduzcvDQwnR0WaXYarBMTHy9OBHFQAAAABQPd41wu3Fx0TLw8WXJHcXnjabrojubHYZAAAAAAA3R8ADtxfs56f48zTkiI+JVrCfn9llAAAAAADcHAEPLGFin0sV4u9vdhkuFRLgr+v7XGp2GQAAAAAACyDggSX4+vjotkEDzC7DpaYNHChfb2+zywAAAAAAWAABDyyjW3i4EmLOjw2XB8dEq2t4mNllAAAAAAAsgoAHljLpPFiqFRLgr4lxfcwuAwAAAABgIQQ8sJTzYakWS7MAAAAAAHVFwAPL6RYerklNdIbLDXF9WJoFAAAAAKgzAh5Y0oju3TSqx8Vml+FUo3r20NXdu5ldBgAAAADAggh4YFnjL+mtoV27mF2GUwzt2kXje/cyuwwAAAAAgEV5mV0AUF82m0039Y1Tc29vfb11m9nl1Nvonj00rncv2Ww2s0sBAAAAAFgUAQ8szWaz6bpLesvPx0cLNyaaXU6dTYrroxEsywIAAAAANBABD5qEEd27qWOrVpqzeo1y8vLMLqdWIQH+mjZwIBsqAwAAAACcgj140GR0DQ/T0+PGKCEm2uxSajQ4JlpPjx1DuAMAAAAAcBpm8KBJ8fX21tQB/RUX2VFzV691q9k8zNoBAAAAADQWZvCgSeoWHq6nx43RkNgYeZi8ebGnzaYhsTHM2gEAAAAANBpm8KDJ8vX21uT+/TSqZw+tSk7RypQU5eYXuGz8ID9fDY6J0RXRnRXs5+eycQEAAAAA5x8CHjR5wX5+Gtu7l0b27KHN+9P10+7dSso62GjjdQ0L05DYGPXqECEvDybJAQAAAAAaHwEPzhteHh6Ki+youMiOysw9pg2pqUrNyVFado6OFdR/Zk+Qr686hoYoKiREfaOiFB4U6MSqAQAAAACoHQEPzkvhQYEa27uX/fbR/HylZecoLefMx5G8PBWVlKiopETFJaXy8vSQt6envD091crfX5EhIWc+QkNYfgUAAAAAMB0BD6Azy7iCO/ipd4cIs0sBAAAAAKDO2CAEAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyuUQOeP/74Q0uWLNH06dM1YsQIhYaGymazyWazaerUqQ71kZ+fr0WLFumvf/2r4uLiFBwcLG9vb4WEhKh///564okndPDgQafUGxkZaa+vpo/IyEinjAcAAAAAAOAMXo3ZeZs2bRp0/23btmngwIE6efJkpXNHjhzR+vXrtX79er322mt6++23NWnSpAaNBwAAAAAAYEWNGvCU16FDB8XGxuqHH35w+D7Hjx+3hzsDBw7UyJEj1adPH4WEhOjw4cNatGiR3nnnHR0/flw333yzWrZsqREjRjS41jFjxujpp5+u9ryPj0+DxwAAAAAAAHCWRg14pk+frri4OMXFxalNmzZKS0tTVFSUw/f38PDQxIkT9fjjj6tr166Vzg8bNkwjRozQuHHjVFJSonvuuUd79uyRzWZrUN1BQUHq3r17g/oAAAAAAABwlUYNeGbMmNGg+w8YMEADBgyosc2YMWM0fvx4ff7559q3b582b96sSy65pEHjAgAAAAAAWEmTuIrW4MGD7cf79u0zsRIAAAAAAADXaxIBz+nTp+3Hnp6eJlYCAAAAAADgek0i4Fm1apX9uEuXLg3u7+eff1avXr3UokUL+fn5KSoqSpMmTdLixYtlGEaD+wcAAAAAAHAml11Fq7Fs3bpV33zzjSTp4osvdkrAk5qaWuF2Wlqa0tLS9Mknn2jgwIFauHCh2rVrV+d+MzIyajyflZVV5z4BAAAAAAAsHfCcPn1at99+u0pKSiRJzzzzTIP68/Hx0ejRozVs2DB1795dgYGBys3N1bp16zRr1iylp6drzZo1Gjp0qNatW6fAwMA69R8REdGg+gAAAAAAAKpi6YDn7rvvVmJioiRpypQpGjVqVIP627Bhg4KCgip9PiEhQXfffbcmTJigH374QUlJSZoxY4ZeffXVBo0HAAAAAADgDJYNeJ577jnNnj1bkhQXF6f/+7//a3CfVYU7ZVq0aKFPPvlEnTp10pEjR/T222/r+eefl4+Pj8P9p6en13g+KytLffv2dbg/AAAAAAAAyaIBz1tvvaX//d//lSTFxsbq22+/lb+/f6OPGxgYqBtuuEFvvvmm8vLylJiYqAEDBjh8//bt2zdidQAAAAAA4HxluatoffTRR/rb3/4mSerYsaOWLVum0NBQl43ftWtX+/GBAwdcNi4AAAAAAEB1LBXwfPXVV5o8ebJKS0sVFham5cuXu3xWjM1mc+l4AAAAAAAAtbFMwLN8+XJNnDhRxcXFCgkJ0bJly3ThhRe6vI5du3bZj8PDw10+PgAAAAAAwLksEfCsXbtWY8aM0enTpxUYGKjvv/9e3bp1c3kdx44d08cffyxJ8vPzU58+fVxeAwAAAAAAwLncPuDZsmWLrr32WuXl5cnf31/ffPONLr300jr3k5CQIJvNJpvNprS0tErnv/vuOxUUFFR7/5MnT2rixInKycmRJE2bNk3NmjWrcx0AAAAAAADO1qhX0Vq9erX27t1rv52dnW0/3rt3r+bNm1eh/dSpUyvc3rdvn4YPH67c3FxJ0tNPP63AwEDt2LGj2jFbt26t1q1b17nW559/XjfffLPGjx+vQYMG6cILL1RAQICOHTumtWvX6j//+Y/2798vSYqJidETTzxR5zEAAAAAAAAaQ6MGPLNnz9b8+fOrPLdmzRqtWbOmwufODXj++9//6o8//rDffuCBB2od8/HHH693+HLkyBHNnj1bs2fPrrZNfHy8FixYoFatWtVrDAAAAAAAAGdr1IDHSl5++WUtX75c69atU3JysrKzs5Wbmys/Pz+Fh4frsssu04033qhhw4ZxJS0AAAAAAOBWbIZhGGYXgTMyMjIUEREhSUpPT3f5JeABAAAAADgfNMX3326/yTIAAAAAAABqRsADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcV5mFwAAQGMxDEO5+flKy8lRWs4RpeXk6EhenoqKS1RUUqLi0lJ5eXjI29NT3l6eauXvr8iQEEWGtFJkaKiC/fzMfggAAACAQwh4AABNSmbuMW1ITVVqdo5Sc7J1vOCUw/dNP3JUW9Mz7LcDfX0VGRKiqNAQ9Y2KUnhQYGOUDAAAADQYAQ8AwPKKS0u1ef9+/ZSUrKSDB53W77GCAm3NyNDWjAwt3rJVXcLaakhsrHp3iJCXB6ucAQAA4D4IeAAAlnU0L08rU/ZoVXKKcgsKGn28pKyDSso6qCA/XyVERys+JpplXAAAAHALBDwAAMspKCzUJ4mbtCplj0oNw+Xj5+YXaPGWrfpq6zbFR3fWxLg+8vX2dnkdAAAAQBkCHgCApezMzNTc1WuVk5dndikqNQytSE7RtowDum3QAHULDze7JAAAAJynCHgAAJZQUFiohRs3aWVKitmlVJKTl6eXvl+mhJhoTWI2DwAAAExAwAMAcHvuNGunJiuTU7Sd2TwAAAAwAZcAAQC4taU7duql75e5fbhTpmw2z9IdO80uBQAAAOcRZvAAANySYRha9Otmfb1tu9ml1MvCjYnKLyzU+N69ZLPZzC4HAAAATRwzeAAAbscwDH24YaNlw50yX2/dpg83bJRhwpW+AAAAcH4h4AEAuJ1Fv27Wsl1JZpfhFMt2JWnR5i1mlwEAAIAmjoAHAOBWlu7YafmZO+f6eus29uQBAABAoyLgAQC4jZ2ZmVq4MdHsMhrFwo2J2pWZZXYZAAAAaKIIeAAAbqGgsFBzV681u4xGNWfNGhUUFZldBgAAAJogAh4AgFtYmLjJMpdCr6+ck3n6pInOUAIAAIC5CHgAAKbbmZmplckpZpfhEiuSU1iqBQAAAKcj4AEAmOp8WJp1LpZqAQAAwNkIeAAApvrkPFiada6ck3n6NHGT2WUAAACgCSHgAQCY5mh+vlal7DG7DFOsSk7R0fx8s8sAAABAE0HAAwAwzarkFJUahtllmKLEMPTzeRpuAQAAwPkIeAAApiguLdXKlPNjY+XqrEhOVnFpqdllAAAAoAkg4AEAmGLz/nTl5heYXYapcvMLtGV/utllAAAAoAkg4AEAmOKn3bvNLsEt/LQ72ewSAAAA0AQQ8AAAXC4zN1dJWQfNLsMt7MrKUmbuMbPLAAAAgMUR8AAAXG5DaprZJbiVDampZpcAAAAAiyPgAQC4XGp2jtkluJXUHJ4PAAAANAwBDwDApQzDUBqBRgW/E3gBAACggQh4AAAulZufr2MF5/fVs86VW1Cgo/n5ZpcBAAAACyPgAQC4FLN3qpbGLB4AAAA0AAEPAMCl0nKOmF2CWyL4AgAAQEMQ8AAAXIogo2o8LwAAAGgIAh4AgEsdycszuwS3xPMCAACAhiDgAQC4VFFxidkluKWiEp4XAAAA1B8BDwDApQgyqsbzAgAAgIYg4AEAuFRxaanZJbil4hKeFwAAANQfAQ8AwKW8PPivpypenjwvAAAAqD9+mwQAuJS3p6fZJbglnhcAAAA0BAEPAMClvL0IMqpCwAMAAICGIOABALhUK39/s0twSzwvAAAAaAgCHgCAS0WGhJhdglvieQEAAEBDEPAAAFwqMqSV2SW4JQIeAAAANAQBDwDApQgyqhYZyvMCAACA+iPgAQC4VJCfnwJ9fc0uw60E+foq2M/P7DIAAABgYQQ8AACXstlszOI5R0dm7wAAAKCBCHgAAC4XRaBRQRSBFwAAABqIgAcA4HJ9o6LMLsGtXNaJ5wMAAAANQ8ADAHC58KBAdQlra3YZbqFrWJjCAgPNLgMAAAAWR8ADADDFkNhYs0twC0NiY8wuAQAAAE0AAQ8AwBS9O0QoyO/8vppWkJ+veneIMLsMAAAANAEEPAAAU3h5eCghOtrsMkw1OCZGnh78VwwAAICG47dKAIBp4mOi5WGzmV2GKTxtNl0R3dnsMgAAANBEEPAAAEwT7Oen+PM05IiPiVawn5/ZZQAAAKCJIOABAJhqYp9LFeLvb3YZLhUS4K/r+1xqdhkAAABoQgh4AACm8vXx0W2DBphdhktNGzhQvt7eZpcBAACAJoSABwBgum7h4UqIOT82XB4cE62u4WFmlwEAAIAmhoAHAOAWJp0HS7VCAvw1Ma6P2WUAAACgCSLgAQC4hfNhqRZLswAAANBYCHgAAG6jW3i4JjXRGS43xPVhaRYAAAAaDQEPAMCtjOjeTaN6XGx2GU41qmcPXd29m9llAAAAoAkj4AEAuJ3xl/TW0K5dzC7DKYZ27aLxvXuZXQYAAACaOC+zCwAA4Fw2m0039Y1Tc29vfb11m9nl1Nvonj00rncv2Ww2s0sBAABAE9eoM3j++OMPLVmyRNOnT9eIESMUGhoqm80mm82mqVOn1rm/pUuXaty4cWrfvr2aNWum9u3ba9y4cVq6dKlT687Pz9eLL76ouLg4tWrVSv7+/oqNjdWDDz6o33//3aljAQCqZrPZdN0lvS27J8+kuD4af0lvwh0AAAC4RKPO4GnTpo1T+iktLdWdd96pOXPmVPj8gQMHdODAAS1evFi333673nrrLXl4NCyz2rt3r6655hrt2bOnwueTk5OVnJys2bNna8GCBRo5cmSDxgEAOGZE927q2KqV5qxeo5y8PLPLqVVIgL+mDRzIhsoAAABwKZftwdOhQwcNGzasXvd99NFH7eFO79699dFHH2nDhg366KOP1Lt3b0nS7Nmz9dhjjzWoxhMnTujaa6+1hzt33HGHli9frrVr1+qZZ55RQECAjh8/rkmTJmnLli0NGgsA4Liu4WF6etwYJcREm11KjQbHROvpsWMIdwAAAOByNsMwjMbq/PHHH1dcXJzi4uLUpk0bpaWlKSoqSpI0ZcoUzZs3r9Y+UlJS1K1bNxUXF6tPnz76+eef5evraz+fn5+v+Ph4JSYmysvLS0lJSbrooovqVe/06dP11FNPSZJefPFFPfTQQxXOr127VvHx8SouLlZ8fLxWrlxZr3Gqk5GRoYiICElSenq62rdv79T+AaAp2JmZqbmr17rVbB5m7QAAAFhLU3z/3agzeGbMmKGRI0c2aKnW66+/ruLiYknSzJkzK4Q7kuTn56eZM2dKkoqLi/Xaa6/Va5yioiK98cYbkqQuXbrowQcfrNRmwIABmjZtmiRp1apV2rhxY73GAgDUX7fwcD09boyGxMbIw+T9bTxtNg2JjWHWDgAAAEzn1pdJNwxDX375pSQpNjZW/fr1q7Jdv379FBMTI0n68ssvVZ9JSStWrNCxY8cknZldVN1ePuU3h/7iiy/qPA4AoOF8vb01uX8/vTJxgsb26qkgP9/a7+REQX6+Gte7l16eOEGT+/eTr7e3S8cHAAAAzuXWl0lPTU1VZmamJCk+Pr7GtvHx8UpOTtaBAwcqLAVz1OrVqyv0VZ0+ffrIz89P+fn5WrNmTZ3GAAA4V7Cfn8b27qWRPXto8/50/bR7t5KyDjbaeF3DwjQkNka9OkTIq4Gb+gMAAADO5NYBz65du+zHsbGxNbYtfz4pKanOAY+jY3l5eemiiy7Stm3blJSUVKcxAACNw8vDQ3GRHRUX2VGZuce0ITVVqTk5SsvO0bGCgnr3G+Trq46hIYoKCVHfqCiFBwU6sWoAAADAedw64MnIyLAf17bhUdnmSNKZDZLqO5a/v7+CgoJqHWvbtm06fPiwTp8+rWbNmtVpjOpkZWU51A8AoHrhQYEa27uX/fbR/HylZecoLefMx5G8PBWVlKiopETFJaXy8vSQt6envD091crfX5EhIWc+QkMU7Odn3gMBAAAA6sCtA54TJ07YjwMCAmps6+/vbz8+efJkvceqbZyqxnI04CkfQgEAXCPYz0/BHfzUuwOvwQAAAGi63HoDgVOnTtmPfXx8amxbPmQpqMd0/LKxahvHGWMBAAAAAAA4k1vP4GnevLn9uLCwsMa2p0+fth+feyn1uoxV2zgNGau2pWNZWVnq27evw/0BAAAAAABIbh7wtGjRwn5c27KrvLw8+7Ejy6yqG8uR5V31Hau2fYQAAAAAAADqw62XaJUPRGrboLj87Jj67HVTNlZeXp5yc3MdGuuCCy5weP8dAAAAAACAxuLWAU/Xrl3tx7t3766xbfnzXbp0abSxiouLtW/fvnqPAwAAAAAA4GxuHfBERUUpPDxckrRq1aoa2/7888+SpHbt2ikyMrLOYw0aNMh+XNNYiYmJ9iVaAwcOrPM4AAAAAAAAzubWAY/NZtOYMWMknZlVs379+irbrV+/3j7rZsyYMbLZbHUeKyEhQYGBgZKk+fPnyzCMKtvNmzfPfjxu3Lg6jwMAAAAAAOBsbh3wSNL9998vT09PSdI999xT6bLkBQUFuueeeyRJXl5euv/++6vsZ+rUqbLZbLLZbFq5cmWl8z4+Prr33nslSUlJSXr55ZcrtVm3bp3mzJkjSYqPj1dcXFx9HxYAAAAAAIDTNOpVtFavXq29e/fab2dnZ9uP9+7dW2E2jHQmhDlXdHS0HnroIT3//PNKTEzUwIED9cgjj+jCCy/Uvn379MILL2jz5s2SpIceekidO3eud70PPfSQFi5cqJSUFD388MPau3evbrjhBvn6+mrFihV69tlnVVxcLF9fX73++uv1HgcAAAAAAMCZbEZ1a5GcYOrUqZo/f77D7asrpbS0VHfccYfmzp1b7X2nTZumt99+Wx4eVU9KKl/LihUrlJCQUGW7vXv36pprrtGePXuqPN+yZUstWLBAI0eOrOGR1E9GRob9CmDp6elcVh0AAAAAgEbQFN9/u/0SLUny8PDQnDlz9M0332jMmDEKDw+Xj4+PwsPDNWbMGH377beaPXt2teFOXVx00UXavHmzXnjhBfXp00dBQUHy8/NTTEyMHnjgAW3btq1Rwh0AAAAAAID6atQZPKibppggAgAAAADgbpri+29LzOABAAAAAABA9Qh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACzOy+wCAAAAgPORYRjKzc9XWk6O0nKOKC0nR0fy8lRUXKKikhIVl5bKy8ND3p6e8vbyVCt/f0WGhCgypJUiQ0MV7Odn9kMAALgRAh4AAADARTJzj2lDaqpSs3OUmpOt4wWnHL5v+pGj2pqeYb8d6OuryJAQRYWGqG9UlMKDAhujZACARRDwAAAAAI2ouLRUm/fv109JyUo6eNBp/R4rKNDWjAxtzcjQ4i1b1SWsrYbExqp3hwh5ebATAwCcbwh4AAAAgEZwNC9PK1P2aFVyinILChp9vKSsg0rKOqggP18lREcrPiaaZVwAcB4h4AEAAACcqKCwUJ8kbtKqlD0qNQyXj5+bX6DFW7bqq63bFB/dWRPj+sjX29vldQAAXIuABwAAAHCSnZmZmrt6rXLy8swuRaWGoRXJKdqWcUC3DRqgbuHhZpcEAGhEBDwAAABAAxUUFmrhxk1amZJidimV5OTl6aXvlykhJlqTmM0DAE2W2+++lpCQIJvNVqePlStX1nmcJ554olH7BwAAQNO0MzNTjy3+yi3DnfJWJqfosS++1M7MTLNLAQA0ArcPeOrKw8NDnTt3NrsMAAAAnAeW7tipl75f5hZLshxRNptn6Y6dZpcCAHAyt1+i9e677yqvlv8wd+3apUmTJkmSrrzySrVr165BY27fvr3G81FRUQ3qHwAAANZmGIYW/bpZX2+r+fdGd7VwY6LyCws1vncv2Ww2s8sBADiB2wc8joQp77//vv148uTJDR6ze/fuDe4DAAAATZNhGPpww0Yt25VkdikN8vXWbTpVVKSb+sYR8gBAE2D5JVqlpaVasGCBJCkgIEDjx483uSIAAAA0ZYt+3Wz5cKfMsl1JWrR5i9llAACcwPIBz/Lly3XgwAFJ0oQJE+Tn52dyRQAAAGiqlu7YadllWdX5eus29uQBgCbA8gHPe++9Zz92xvIsAAAAoCo7MzO1cGOi2WU0ioUbE7UrM8vsMgAADeD2e/DU5OTJk/riiy8kSR07dlRCQoJT+h02bJi2bNmi3NxcBQUFqWvXrrr66qv15z//WcHBwfXuNyMjo8bzWVn8pwoAAOCOCgoLNXf1WrPLaFRz1qzR02PHyNfb2+xSAAD1YOmA5/PPP7dfYetPf/qT0zaHW7Zsmf348OHDWrVqlVatWqUXXnhB8+bN05gxY+rVb0REhFPqAwAAgGstTNxkmUuh11fOyTx9sjFRUwb0N7sUAEA9WHqJlrOXZ1188cX65z//qa+//lqbNm3S+vXrNX/+fA0bNkySlJubq+uuu05Lly5t8FgAAACwhp2ZmVqZnGJ2GS6xIjmFpVoAYFE2wzAMs4uoj4yMDHXs2FGlpaXq16+f1q1b16D+ypZjVeett97SX/7yF0lSeHi49u3bp+bNm9dpDEeWaPXt21eSlJ6ervbt29epfwAAADhXQWGhHlv8VZOfvVNeSIA/S7UANHkZGRn2VTZN5f23ZZdoffDBByotLZUkTZkypcH91RTuSNKf//xnbdy4UXPmzFFmZqY+//xz3XzzzXUaoyl8wwAAAJxPPjkPlmadK+dknj5N3KTJ/fuZXQoAoA4su0Tr/ffflyQ1a9ZMkyZNcsmYf/7zn+3Hq1atcsmYAAAAMMfR/HytStljdhmmWJWcoqP5+WaXAQCoA0sGPImJidq1a5ckaeTIkQ26slVddO3a1X584MABl4wJAAAAc6xKTlGpNXczaLASw9DP52m4BQBWZcmAp/zmys5YnuUoZ12lCwAAAO6tuLRUK1POj42Vq7MiOVnFZ7dEAAC4P8sFPEVFRfr4448lSRdccIFGjBjhsrHLZg1JZzZaBgAAQNO0eX+6cvMLzC7DVLn5BdqyP93sMgAADrJcwLN06VIdPnxYknTTTTfJy8t1+0S/9dZb9uP4+HiXjQsAAADX+mn3brNLcAs/7U42uwQAgIMsF/CUX541efJkh+4zb9482Ww22Ww2PfHEE5XOb9++XXv37q2xj7fffluzZ8+WJLVt21bjxo1zvGgAAABYRmZurpKyDppdhlvYlZWlzNxjZpcBAHCApS6TfvToUS1ZskSS1L17d11yySVO6XfTpk26/fbbNXjwYI0YMUIXX3yxQkJCVFxcrN27d2vBggX64YcfJEmenp56++235e/v75SxAQAA4F42pKaZXYJb2ZCaqrG9e5ldBgCgFpYKeBYuXKjTp09Lcnz2jqNKSkr0448/6scff6y2TUhIiObMmaNRo0Y5dWwAAAC4j9TsHLNLcCupOTwfAGAFlgp43n//fUlnZtHcfPPNTuv3mmuu0Zw5c7Ru3Tpt3rxZhw4dUk5OjgzDUKtWrdSzZ09dffXVmjp1qlq2bOm0cQEAAOBeDMNQGoFGBb8TeAGAJdgMwzDMLgJnZGRkKCIiQpKUnp6u9u3bm1wRAADA+eVoXp4e+OQzs8twO69Nul7Bfn5mlwEATtMU339bbpNlAAAAoLEwe6dqacziAQC3R8ADAAAAnJWWc8TsEtwSwRcAuD8CHgAAAOAsgoyq8bwAgPsj4AEAAADOOpKXZ3YJbonnBQDcHwEPAAAAcFZRcYnZJbilohKeFwBwdwQ8AAAAwFkEGVXjeQEA90fAAwAAAJxVXFpqdgluqbiE5wUA3B0BDwAAAHCWlwe/HlfFy5PnBQDcHa/UAAAAwFnenp5ml+CWeF4AwP0R8AAAAABneXsRZFSFgAcA3B8BDwAAAHBWK39/s0twSzwvAOD+CHgAAACAsyJDQswuwS3xvACA+yPgAQAAAM6KDGlldgluiYAHANwfAQ8AAABwFkFG1SJDeV4AwN0R8AAAAABnBfn5KdDX1+wy3EqQr6+C/fzMLgMAUAsCHgAAAOAsm83GLJ5zdGT2DgBYAgEPAAAAUE4UgUYFUQReAGAJBDwAAABAOX2joswuwa1c1onnAwCsgIAHAAAAKCc8KFBdwtqaXYZb6BoWprDAQLPLAAA4gIAHAAAAOMeQ2FizS3ALQ2JjzC4BAOAgAh4AAADgHL07RCjI7/y+mlaQn696d4gwuwwAgIMIeAAAAIBzeHl4KCE62uwyTDU4JkaeHrxdAACr4BUbAAAAqEJ8TLQ8bDazyzCFp82mK6I7m10GAKAOCHgAAACAKgT7+Sn+PA054mOiFeznZ3YZAIA6IOABAAAAqjGxz6UK8fc3uwyXCgnw1/V9LjW7DABAHRHwAAAAANXw9fHRbYMGmF2GS00bOFC+3t5mlwEAqCMCHgAAAKAG3cLDlRBzfmy4PDgmWl3Dw8wuAwBQDwQ8AAAAQC0mnQdLtUIC/DUxro/ZZQAA6omABwAAAKjF+bBUi6VZAGBtBDwAAACAA7qFh2tSE53hckNcH5ZmAYDFEfAAAAAADhrRvZtG9bjY7DKcalTPHrq6ezezywAANBABDwAAAFAH4y/praFdu5hdhlMM7dpF43v3MrsMAIATeJldAAAAAGAlNptNN/WNU3Nvb329dZvZ5dTb6J49NK53L9lsNrNLAQA4AQEPAAAAUEc2m03XXdJbfj4+Wrgx0exy6mxSXB+NYFkWADQpBDwAAABAPY3o3k0dW7XSnNVrlJOXZ3Y5tQoJ8Ne0gQPZUBkAmiD24AEAAAAaoGt4mJ4eN0YJMdFml1KjwTHRenrsGMIdAGiimMEDAAAANJCvt7emDuivuMiOmrt6rVvN5mHWDgCcH5jBAwAAADhJt/BwPT1ujIbExsjD5M2LPW02DYmNYdYOAJwnmMEDAAAAOJGvt7cm9++nUT17aFVyilampCg3v8Bl4wf5+WpwTIyuiO6sYD8/l40LADAXAQ8AAADQCIL9/DS2dy+N7NlDm/en66fdu5WUdbDRxusaFqYhsTHq1SFCXh5M1AeA8w0BDwAAANCIvDw8FBfZUXGRHZWZe0wbUlOVmpOjtOwcHSuo/8yeIF9fdQwNUVRIiPpGRSk8KNCJVQMArIaABwAAAHCR8KBAje3dy377aH6+0rJzlJZz5uNIXp6KSkpUVFKi4pJSeXl6yNvTU96enmrl76/IkJAzH6EhLL8CAFRAwAMAAACYJNjPT8Ed/NS7Q4TZpQAALI7FuQAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWZ4mAx2azOfSRkJDglPE++ugjDRs2TG3btlXz5s3VsWNH/elPf9K6deuc0j8AAAAAAIAzWSLgcZWCggJde+21uummm7Rs2TIdOnRIp0+f1v79+7VgwQINGjRIM2bMMLtMAAAAAACACrzMLqAu/vrXv+pvf/tbtef9/f0b1P9tt92mb7/9VpI0ePBg3XfffQoPD9f27dv17LPPat++fXriiScUFhamO++8s0FjAQAAAAAAOIulAp7WrVure/fujdL3Tz/9pI8//liSNGrUKH3xxRfy9PSUJMXFxWn06NG69NJLtX//fj3yyCO6/vrrFRwc3Ci1AAAAAAAA1AVLtM56+eWXJUleXl5688037eFOmdDQUL3wwguSpNzcXM2ePdvlNQIAAAAAAFSFgEfSiRMntHz5cknSVVddpfbt21fZbvz48WrZsqUk6YsvvnBZfQAAAAAAADUh4JG0ceNGFRYWSpLi4+Orbefj46N+/frZ71NUVOSS+gAAAAAAAGpiqYDn008/VdeuXeXn56cWLVqoc+fOmjJlilasWNGgfnft2mU/jo2NrbFt2fni4mLt2bOnQeMCAAAAAAA4g6U2WS4fxEjS3r17tXfvXr333nsaO3as5s2bp8DAwDr3m5GRYT+ubnlWmYiICPtxenq6unbtWq9xqpKVleVwXwAAAAAAAGUsEfD4+flp9OjRuvLKKxUbG6uAgAAdPnxYq1at0n/+8x/l5ORo8eLFGjNmjJYtWyZvb+869X/ixAn7cUBAQI1ty1+K/eTJk3Uap3w4BAAAAAAA4CyWCHgOHDigoKCgSp8fOnSo7rnnHo0YMUKbN2/WqlWrNGvWLN1777116v/UqVP2Yx8fnxrbNmvWzH5cUFBQp3EAAAAAAAAagyUCnqrCnTJt2rTRZ599ptjYWBUVFWnmzJl1DniaN29uPy7bbLk6p0+fth/7+vrWaZz09PQaz2dlZalv37516hMAAAAAAMASAU9tOnXqpKFDh+rbb7/V3r17lZmZqfDwcIfv36JFC/txbcuu8vLy7Me1Lec6V237+wAAAAAAANSHpa6iVZPymx0fOHCgTvctH7zUthFy+Vk47KkDAAAAAADcQZMJeGw2W73vWz4c2r17d41ty857eXmpc+fO9R4TAAAAAADAWZpMwFP+Eup1WZ4lSXFxcfbNlVetWlVtu8LCQq1fv95+n7perQsAAAAAAKAxNImAJzU1VcuWLZMkXXjhhWrXrl2d7t+iRQtdeeWVkqQff/yx2mVaixYt0vHjxyVJ48aNa0DFAAAAAAAAzuP2Ac/XX3+t4uLias8fOnRI1113nf3qV3/7298qtZk3b55sNptsNpueeOKJKvv5n//5H0lScXGx7rrrLpWUlFQ4n52drUceeUTSmat63X777fV5OAAAAAAAAE7n9lfRuueee1RUVKTrrrtO/fv3V2RkpHx9fZWdna2VK1fqrbfeUnZ2tiRp0KBBuuuuu+o1zpAhQ3TDDTfo448/1ldffaWhQ4fq/vvvV3h4uLZv365nnnlG+/fvlyS98MILCg4OdtpjBAAAAAAAaAi3D3gkKTMzUzNnztTMmTOrbXPddddp9uzZatasWb3HmTt3ro4fP65vv/1WK1as0IoVKyqc9/Dw0D//+U/deeed9R4DAAAAAADA2dw+4Jk/f75WrVqldevW6bffflN2draOHz+ugIAARUREaMCAAZoyZYr69+/f4LF8fX31zTff6MMPP9S8efO0detW5ebmqk2bNrr88st19913O2UcAAAAAAAAZ7IZhmGYXQTOyMjIUEREhCQpPT1d7du3N7kiAAAAAACanqb4/tvtN1kGAAAAAABAzQh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALO7/t3fnwVWV9x/HP1kMZCEswRRC2ARiUNFSAUGEEJUgawxUwKoshRq1UGgZ8FdtMb8OKGKpZZyODRqhuACC/pBFWpCGIBCEYMZS2UOwCYk2oYQtAXKT8/uDyWkw211ObnKS92smM0fvyfN9bh6ee+753OeeQ8ADAAAAAABgcwQ8AAAAAAAANkfAAwAAAAAAYHMEPAAAAAAAADZHwAMAAAAAAGBzBDwAAAAAAAA2R8ADAAAAAABgcwQ8AAAAAAAANkfAAwAAAAAAYHMEPAAAAAAAADZHwAMAAAAAAGBzBDwAAAAAAAA2R8ADAAAAAABgcwQ8AAAAAAAANkfAAwAAAAAAYHMEPAAAAAAAADZHwAMAAAAAAGBzBDwAAAAAAAA2R8ADAAAAAABgcwQ8AAAAAAAANkfAAwAAAAAAYHMEPAAAAAAAADZHwAMAAAAAAGBzBDwAAAAAAAA2R8ADAAAAAABgcwQ8AAAAAAAANkfAAwAAAAAAYHMEPAAAAAAAADZHwAMAAAAAAGBzBDwAAAAAAAA2R8ADAAAAAABgcwQ8AAAAAAAANkfAAwAAAAAAYHMEPAAAAAAAADZHwAMAAAAAAGBzBDwAAAAAAAA2R8ADAAAAAABgcwQ8AAAAAAAANkfAAwAAAAAAYHMEPAAAAAAAADZHwAMAAAAAAGBzBDwAAAAAAAA2R8ADAAAAAABgcwQ8AAAAAAAANkfAAwAAAAAAYHMEPAAAAAAAADZHwAMAAAAAAGBzBDwAAAAAAAA2R8ADAAAAAABgcwQ8AAAAAAAANkfAAwAAAAAAYHMEPAAAAAAAADZHwAMAAAAAAGBzBDwAAAAAAAA2R8ADAAAAAABgcwQ8AAAAAAAANmeLgCcjI0O/+93vFBcXp8jISLVo0UIhISGKiorS9OnTtWfPHkvqJCUlycfHx6mfXbt2WVITAAAAAADAU/4N3YG6DB06VJ9//nmV/3/9+nWdPHlSJ0+e1KpVqzRlyhS99dZbCggIaIBeAgAAAAAANJxGH/Dk5eVJkiIiIvTYY49pyJAh6tKli8rKypSenq5ly5bp7NmzWr16tUpLS/XBBx9YUvfw4cO1Pt69e3dL6gAAAAAAAHiq0Qc80dHRevnllzVhwgT5+fnd9NjAgQP11FNPafDgwTpx4oTWrFmjZ555RkOHDvW47l133eVxGwAAAAAAAN7Q6K/Bs2XLFk2cOLFKuFOhffv2WrZsmfnfGzZs8FbXAAAAAAAAGoVGH/A4IzY21tzOyspqwJ4AAAAAAAB4X5MIeK5du2Zu17TSBwAAAAAAoKlqEgFPWlqaud27d29L2oyLi1N4eLgCAgIUHh6uYcOGacmSJTp//rwl7QMAAAAAAFil0V9kuS7l5eVasmSJ+d8TJ060pN0dO3aY2wUFBUpLS1NaWppeffVVrVq1SvHx8S63mZubW+vj+fn5LrcJAAAAAABg+4Dn9ddf14EDByRJ48eP17333utRe3369NGjjz6qAQMGKCIiQqWlpTp+/Ljef/99bd++XUVFRZowYYI2b96skSNHutR2586dPeobAAAAAABAdXwMwzAauhPuSktL08MPPyyHw6Hw8HAdPnxY4eHhbrdXVFSkNm3a1Ph4cnKynnnmGUlSRESEsrKy1LJlS6fb9/HxcXrfnJwcRUZGOr0/AAAAAABwTm5urrkIo6mcf9t2Bc/XX3+thIQEORwOtWzZUuvXr/co3JFUa7gjSYmJiTp48KBSUlKUl5enjz76SE888YTT7efk5NT6eH5+vgYMGOB0ewAAAAAAAJJNA57s7GzFxcXp/Pnz8vPz09q1azV06FCv1E5MTFRKSoqkGyuIXAl4mkIiCAAAAAAAGh/b3UUrLy9PDz/8sPLy8uTj46N33nnHrQseu+uOO+4wt8+ePeu1ugAAAAAAADWxVcBTWFio4cOH6/Tp05KkN954Q1OmTPFqH1y5jg4AAAAAAIA32CbguXDhgkaMGKEjR45IkpYsWaKf//znXu9HRX3pxoWWAQAAAAAAGpotAp7i4mKNHj1aX375pSTpxRdf1PPPP98gfUlOTja3Y2JiGqQPAAAAAAAAlTX6gOf69etKSEjQ3r17JUlz5szRokWLXG5n1apV8vHxkY+Pj5KSkqo8fvjwYZ06darWNlasWKG3335bktShQwclJCS43A8AAAAAAACrNfq7aD3++OPavn27JOnBBx/UjBkz9M9//rPG/QMCAhQVFeVynUOHDmnmzJmKjY3VyJEj1adPH4WFhcnhcOjYsWN6//33zX74+flpxYoVCg4Odu9JAQAAAAAAWKjRBzwff/yxuf33v/9dd999d637d+3aVWfOnHGrVllZmT777DN99tlnNe4TFhamlJQUjR071q0aAAAAAAAAVmv0AY+3jBo1SikpKUpPT1dmZqa+++47nTt3ToZhqF27drrnnnv0yCOPaNq0aQoNDW3o7gIAAAAAAJh8DMMwGroTuCE3N1edO3eWJOXk5CgyMrKBewQAAAAAQNPTFM+/G/1FlgEAAAAAAFA7Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDnbBTzffPON5s2bp+joaAUHB6tdu3bq37+/XnvtNRUXF1tWZ9u2bUpISFBkZKRatGihyMhIJSQkaNu2bZbVAAAAAAAAsIKPYRhGQ3fCWZs3b9aTTz6pixcvVvt4VFSUtm7dqp49e7pdo7y8XE8//bRSUlJq3GfmzJlKTk6Wr6+1+Vhubq46d+4sScrJyVFkZKSl7QMAAAAAgKZ5/m2bFTyZmZmaNGmSLl68qJCQEC1evFj79u3Tzp079bOf/UySdOLECY0ePVqXLl1yu86LL75ohjt9+/bVmjVrdODAAa1Zs0Z9+/aVJL399tv6zW9+4/mTAgAAAAAAsIBtVvAMHTpUn3/+ufz9/bV7924NGjTopsdfe+01LViwQJL00ksvKSkpyeUaJ06c0J133imHw6F+/fpp9+7dCgwMNB8vLi5WTEyMMjIy5O/vr6NHj3q0Wuj7mmKCCAAAAABAY9MUz79tsYLnwIED+vzzzyVJM2bMqBLuSNK8efPUu3dvSdLy5ctVWlrqcp0//vGPcjgckqQ33njjpnBHkoKCgvTGG29IkhwOh15//XWXawAAAAAAAFjNFgHPxo0bze3p06dXu4+vr6+mTJkiSSoqKlJqaqpLNQzD0CeffCJJio6O1sCBA6vdb+DAgbr99tslSZ988olssgAKAAAAAAA0YbYIePbs2SNJCg4O1r333lvjfjExMeb23r17XaqRnZ2tvLy8Ku3UVufs2bM6c+aMS3UAAAAAAACsZouA5+jRo5Kknj17yt/fv8b9oqOjq/yOs44cOVJtO1bXAQAAAAAAsFrNaUkjcfXqVRUWFkpSnRc9atu2rYKDg3XlyhXl5OS4VCc3N9fcrqtOxYWYJLlUp3KN6lRuKz8/3+l2AQAAAACA8yqfc1dci9fuGn3AU/mW5yEhIXXuXxHwXL58ud7qBAcHm9uu1KkcDNVlwIABTu8LAAAAAADcU1BQoG7dujV0NzzW6L+idfXqVXM7ICCgzv1btGghSSopKam3OhU13KkDAAAAAAAaj++++66hu2CJRr+Cp2XLlub29evX69z/2rVrklTlFudW1qmo4Wqdur7OlZ2draFDh0qS9u3b59KKH9hPfn6+uVLrwIED6tixYwP3CPWJ8W5eGO/mhfFuXhjv5oXxbl4Y7+YlJydH999/v6S6r8NrF40+4GnVqpW57czXoa5cuSLJua9zuVunooardeq6tk9lnTt3dml/2FvHjh0Z72aE8W5eGO/mhfFuXhjv5oXxbl4Y7+al8oIPO2v0X9Fq2bKlwsLCJNV9keLz58+b4Yurq18qT15XLobMKhsAAAAAANDQGn3AI0l33HGHJOnUqVO1Xt362LFj5nbv3r3dqvH9dqyuAwAAAAAAYDVbBDwPPPCApBtfjTp06FCN+6WlpZnbgwcPdqlG9+7dFRERUaWd6uzevVuS1KlTpyZxpW0AAAAAAGBvtgh4Hn30UXN75cqV1e5TXl6u1atXS5LatGmj2NhYl2r4+PgoPj5e0o0VOvv37692v/3795sreOLj4+Xj4+NSHQAAAAAAAKvZIuAZMGCAhgwZIklKSUlRenp6lX2WLVumo0ePSpLmzJmjW2655abHd+3aJR8fH/n4+GjatGnV1pk7d678/PwkSbNnz65yC/SSkhLNnj1bkuTv76+5c+d68rQAAAAAAAAsYYuAR5KWL1+uwMBAORwOxcXF6ZVXXtH+/fuVmpqqxMRELViwQJIUFRWlefPmuVUjKipK8+fPlyRlZGRo8ODBWrdunTIyMrRu3ToNHjxYGRkZkqT58+erV69e1jw5AAAAAAAADzT626RX6Nu3r9atW6cnn3xSFy9e1AsvvFBln6ioKG3duvWmW567avHixfr3v/+td955R5mZmZo8eXKVfWbMmKFFixa5XQMAAAAAAMBKPoZhGA3dCVd88803Wr58ubZu3arc3FwFBASoZ8+eeuyxxzRr1iwFBQVV+3u7du0yr8szdepUrVq1qtY6n376qVasWKGDBw+qsLBQ7du3V//+/ZWYmKiRI0da/bQAAAAAAADcZruABwAAAAAAADezzTV4AAAAAAAAUD0CHgAAAAAAAJsj4AEAAAAAALA5Ah4AAAAAAACbI+ABAAAAAACwOQIeAAAAAAAAmyPgAQAAAAAAsDkCHgAAAAAAAJsj4KkH33zzjebNm6fo6GgFBwerXbt26t+/v1577TUVFxdbVmfbtm1KSEhQZGSkWrRoocjISCUkJGjbtm2W1UD1MjIy9Lvf/U5xcXHm3z8kJERRUVGaPn269uzZY0mdpKQk+fj4OPWza9cuS2qiKmfHYNiwYZbUW7NmjeLi4tShQwe1bNlSXbt21ZNPPqn09HRL2kfthg0b5vSYezL/mN/179///re2bNmihQsXauTIkWrfvr35N502bZrL7XnruFtcXKylS5eqf//+ateunYKDgxUdHa158+bpm2++sbRWU2PFmBcXF+vjjz/Ws88+q/79+6tt27a65ZZbFBYWpkGDBikpKUnffvutJf3t1q2bU68B3bp1s6ReU2PFeK9atcrp1+JVq1ZZ0u/CwkItXLhQd999t0JDQxUaGqq7775bCxcu1Llz5yyp0RR5Ot5nzpxx+fjuydxjfrvP6nOtZnX8NmCpTZs2GaGhoYakan+ioqKMkydPelSjrKzMmDFjRo01JBkzZ840ysrKLHpWqGzIkCG1/u0rfqZMmWJcu3bNo1ovvfSSU7UkGampqdY8QVTh7BjExMR4VKe4uNgYNWpUje37+voaSUlJ1jwp1CgmJsbpMa8Yl9zcXJfrML/rX21/06lTpzrdjjePuydPnjR69epVY53Q0FBj8+bNHtdpqjwd86+++soICQmpc06GhoYaa9eu9bi/Xbt2deo1oGvXrh7XaoqsmOMrV650+rV45cqVHvd5//79RocOHWqs0bFjR+OLL77wuE5T5Ol4Z2dnu3R8l2TExcW53V/mt3usPNdqjsdvf8EymZmZmjRpkkpKShQSEqJf//rXio2NVUlJidauXau33npLJ06c0OjRo5WRkaFWrVq5VefFF19USkqKJKlv375asGCBevTooaysLC1dulSZmZl6++23deutt+rll1+28ilCUl5eniQpIiJCjz32mIYMGaIuXbqorKxM6enpWrZsmc6ePavVq1ertLRUH3zwgSV1Dx8+XOvj3bt3t6QOavbss8/queeeq/Hx4OBgj9r/6U9/qk8//VSSFBsbqzlz5igiIkKHDx/Wyy+/rKysLCUlJaljx456+umnPaqFmq1cuVJXrlypdZ8jR45o0qRJkqSHHnpInTp18qgm87v+denSRdHR0dq+fbvLv+ut4+6lS5c0evRonTx5UpL0s5/9TJMnT1ZgYKBSU1P1yiuv6OLFi5o0aZL27t2rH/7wh27Xag7cGfOLFy/q8uXLkqTBgwdrzJgx6tevn8LCwlRQUKCPP/5Yb731li5evKgnnnhCoaGhGjlypMd9jY+P16JFi2p8PCAgwOMaTZ0nc7zC3/72N0VERNT4eGRkpNttS1JOTo7Gjh2rgoIC+fv761e/+pXGjBkjSdqyZYv+8Ic/KD8/X2PHjtWhQ4c8rteUuTPenTp1qvN4K0mvvPKK+f596tSpbvexAvPbNVaeazXL43e9R0jNSEXa6O/vb+zbt6/K40uXLjUTvJdeesmtGsePHzf8/f0NSUa/fv2M4uLimx6/cuWK0a9fP7Mfnq4WQlWjR4821q1bZzgcjmofLygoMKKiosyxTktLc7tW5U/40XA8nbfO2Llzp1ln7NixVf59FRQUGF26dDEkGW3atDH+85//1FtfULcFCxaY4/Xuu++61Qbzu/4tXLjQ2Lx5s/Htt98ahnHzp7fOfrrvzePub3/7W7N/S5curfL43r17zb54umKwqfJ0zPfu3WtMnDjR+Prrr2vcZ+PGjYaPj48hyejRo4dRXl7udn8rPuF3ZUUZ/suKOV55BU92dnb9ddYwjKeeesqs9eGHH1Z5fN26dS73vzmxYrzr4nA4jIiICEOS0apVqyqv+a5gfrvHqnOt5nr85l2lRb744gtzUBMTE6vdp6yszOjdu7d5gnb9+nWX6zz77LNmnfT09Gr3SU9PN/d57rnnXK4Bz23evNkcg9mzZ7vdDieAjYM3Ap6RI0eaB5icnJxq91mzZk2tBw94R1lZmdGpUydDkhESEmJcuXLFrXaY397nzsmAt467169fN1q3bm1IMnr37l3jcvHExESz1oEDB9yq1ZzUxwmgYRjGhAkTzHYPHTrkdjucAFqrMQc8+fn5hq+vryHJGDFiRI37jRgxwpBufP03Pz+/3vrTFNTH/P7rX/9qtjl9+nSP2mJ+1x9nzrWa6/GbiyxbZOPGjeb29OnTq93H19dXU6ZMkSQVFRUpNTXVpRqGYeiTTz6RJEVHR2vgwIHV7jdw4EDdfvvtkqRPPvlEhmG4VAeei42NNbezsrIasCewg0uXLmnnzp2SpIcffrjGJdnjx49XaGioJOn//u//vNY/3Gznzp06e/asJOnHP/6xgoKCGrhHqC/ePO6mpqbqwoULkm58JcDXt/q3aJUvJMrrQMPhOA9Xbdq0SeXl5ZJqPleQ/jvHy8vLtWnTJm90DZWsXr3a3Lbi61moH3W9Bjfn4zcBj0UqruQdHByse++9t8b9YmJizO29e/e6VCM7O9v8TmLldmqrc/bsWZ05c8alOvDctWvXzG0/P78G7Ans4ODBg7p+/bqk2ud2QECAeYA6ePCgSktLvdI/3Kzym7+K0B5NkzePu5XvCFJbrX79+pmhoqvvI2AdjvNwlbNz3JNzBXjm0qVL5of23bp109ChQxu2Q6hRXa/Bzfn4TcBjkaNHj0qSevbsKX//mq9dHR0dXeV3nHXkyJFq27G6DjyXlpZmbvfu3duSNuPi4hQeHq6AgACFh4dr2LBhWrJkic6fP29J+6jb+vXrdccddygoKEitWrVSr169NHXqVJdX432fO3Pb4XCYF3KD91y+fNn81KVr164aNmyYJe0yvxsnbx53na3l7++vnj17ul0H1rD6OL9792798Ic/VKtWrRQUFKTu3btr0qRJ2rhxIyuxvWj69OmKiIhQQECA2rdvr4EDB+o3v/mNuWrTExVzvHXr1urQoUON+3Xs2NFcrcsc964NGzaouLhYkvTUU0/Jx8fHknaZ39ar6zW4OR+/CXgscPXqVRUWFkqq++r6bdu2Ne+0k5OT41Kd3Nxcc7uuOp07dza3Xa0Dz5SXl2vJkiXmf0+cONGSdnfs2KGCggKVlpaqoKBAaWlp+vWvf63bbrvNXIKI+nXkyBEdPXpUJSUlunz5sk6dOqXVq1frwQcfVEJCgrk801XMbfv46KOPzDtsPfnkk5a9+WN+N07enJsVtYKDg9WmTRunahUUFNz0KSa846uvvtLWrVslSX369LEk4MnOztZXX32ly5cvq6SkRGfOnNGHH36ohIQEDRkyxJKAAXXbtWuX8vPzVVpaqnPnzumLL77Q4sWL1bNnTyUnJ3vUdsUcd+bOWBVznOO8d9XXCl3mt7WcOddqzsdvbpNugUuXLpnbISEhde4fHBysK1eumLfhrI86lW/X7GodeOb111/XgQMHJN24ZkptX9lzRp8+ffToo49qwIABioiIUGlpqY4fP673339f27dvV1FRkSZMmKDNmzdbcqtWVBUUFKRx48bpoYceUnR0tEJCQsyT8D//+c86d+6cNm7cqPj4eO3YsUO33HKLS+0zt+3D6jd/zO/GzZtzs6KWs+8jKtdq0aKFy/XgnmvXrmnmzJkqKyuTJC1evNij9gICAjRu3DjFxcXprrvuUuvWrVVUVKT09HS9+eabysnJ0d69ezV8+HClp6erdevWVjwNfM9tt92m8ePHa9CgQeYJ2OnTp/XRRx9pw4YNunr1qp555hn5+Pjo6aefdquGO3Oc47z3/Otf/zJXhdx///3mSgtPML/rhzPnWs35+E3AY4GrV6+a2wEBAXXuXzGQJSUl9Van8j8WV+vAfWlpafqf//kfSVJ4eLjefPNNj9qbO3eukpKSqvz/++67T1OmTFFycrKeeeYZlZWVaebMmcrKylLLli09qomqzp49W20iP3z4cM2ePVsjR45UZmam0tLS9Oabb+oXv/iFS+0zt+0hNzdXu3btknTjonxRUVEetcf8bvy8OTcrarnyPsLdWnDfrFmzlJGRIenGxTTHjh3rUXsHDhyo9vgybNgwzZo1Sz/+8Y+1fft2HT16VP/7v/+rP/zhDx7VQ1UJCQmaOnVqlRWZ/fv316RJk7RlyxaNHz9epaWl+uUvf6lx48bV+hWrmrgzx5nf3vPee++ZX5eyavUO89t6zp5rNefjN1/RskDlN9wVF0qtTcVyrMDAwHqrU3nJl6t14J6vv/5aCQkJcjgcatmypdavX6/w8HCP2qxrmV9iYqJmzJghScrLy9NHH33kUT1Ur7Zx+MEPfqANGzaYq3beeOMNl9tnbtvDe++9Z94BxYo7azC/Gz9vzs2KWq68j3C3Ftzzyiuv6O2335Z04+T/T3/6k8dt1vY60KpVK3344Ydq166dJGnFihVO/fuAa1q3bl3r123HjBmjhQsXSpKKi4uVkpLiVh135jjz23veffddSTdOwCdNmmRJm8xva7lyrtWcj98EPBZo1aqVue3Msq6K6zc4s4zL3ToVNdypA9dlZ2crLi5O58+fl5+fn9auXeu1K+8nJiaa25UvOAbvue222zR8+HBJ0qlTp8yr9juLuW0P9fHmry7M74blzblZUcuV9xHu1oLrkpOT9cILL0i6cRHNTz/99Kal9vWldevWmjx5sqQb416xegje9fTTT5shkLuvxe7Mcea3dxw4cEDHjh2TJI0bN67OD2Cswvx2nqvnWs35+E3AY4GWLVsqLCxM0s0XdKrO+fPnzYGtfEEnZ1S+QFRddSpfIMrVOnBNXl6eHn74YeXl5cnHx0fvvPOO4uPjvVb/jjvuMLe5SFvD8WQcmNuNX0ZGhnmXhDFjxqht27Zeqcv8bljenJsVta5cuaKioiKnat16661cf8cL1qxZo+eee07Sjbvn7dixQ+3bt/dafV4HGl54eLj5Xt/dMaiY43W9lkj/neMc572jvi6u7Azmd93cOddqzsdvAh6LVEzOU6dOyeFw1LhfRTosuX5bzcovAJXbsboOnFdYWKjhw4fr9OnTkm58PcfbBwar7uIDz3gyDu7MbX9/f/Xq1cvtmnBN5Td/Vnw9y1nM74blzeOus7UcDoeysrLcrgPXbNq0SVOmTFF5ebk6duyonTt3OnUXJCvxOtA4eDoOFXP8woUL+vbbb2vcLz8/XxcvXpTEHPeG0tJSrV27VtKNIO+RRx7xan3md+3cPddqzsdvAh6LPPDAA5JuJHeHDh2qcb/KyzoHDx7sUo3u3bsrIiKiSjvV2b17tySpU6dO6tatm0t14JwLFy5oxIgR5qf6S5Ys0c9//nOv96OiviTz3we8z5Nx6N+/v3lhttrm9vXr17V//37zd1y9WxfcU/nN36233urVu1kxvxuWN4+7Fe8j6qqVkZFhrgR29X0EXLNz505NnDhRDodDYWFh2rFjh3r06OH1fvA60PAKCgpUWFgoyf0xcHaOe3KuANdt3bpV586dkyT95Cc/kb+/d+9BxPyumSfnWs35+E3AY5FHH33U3F65cmW1+5SXl5ufArdp00axsbEu1fDx8TGXox07dsw80fu+/fv3m+lhfHw8yXA9KC4u1ujRo/Xll19Kkl588UU9//zzDdKX5ORkczsmJqZB+tDcZWdna8eOHZKkHj16qFOnTi79fqtWrfTQQw9Jkj777LMal5J+/PHH5qd6CQkJHvQYrti2bZsKCgokef/NH/O7YXnzuDts2DDzFrl/+ctfzLu5fN+qVavMbV4H6s++ffsUHx+va9euqXXr1vrb3/6mO++80+v9uHDhghkwBwUFqV+/fl7vA25cALdiTrr7Wjxu3Dj5+t449arpXEH67xz39fXVuHHj3KoF5zXUCl2J+V0bT8+1mvXx24BlhgwZYkgy/P39jX379lV5fOnSpYYkQ5Lx0ksvVXk8NTXVfHzq1KnV1jh+/Ljh5+dnSDL69etnFBcX3/R4cXGx0a9fP7MfJ06csOKpoZJr164ZcXFx5ljNmTPHrXZWrlxZ67+Hf/zjH8bJkydrbSM5Odlso0OHDsbly5fd6gtqtmnTJqO0tLTGx7/99lujb9++5jgsW7asyj51jbVhGMbOnTvNfcaNG2c4HI6bHi8oKDC6dOliSDLatGlj/Oc///HoecF5EyZMMMfm0KFDTv0O87txys7OrvM4+31WHXenTp1q1k5NTa12n9/+9rfmPkuXLq3y+L59+wx/f39DkhETE+NU/5s7d8Y8MzPTaNOmjSHJCA4ONvbs2eNW7ZiYGLN2dnZ2lce3bdtW5d9TZZcuXbrp/cbs2bPd6kdz4up4Z2dnG19++WWt+2zevNkICAgwJBmBgYFGbm5utfvVNd6GYRhPPfWUuc/69eurPP7hhx+6/O+1OXNnfld27tw5c2z79Onj0u8yv+uPVedazfX47d01aE3c8uXLNXjwYJWUlCguLk4vvPCCYmNjVVJSorVr12rFihWSpKioKM2bN8+tGlFRUZo/f76WLFmijIwMDR48WM8//7x69OihrKwsvfrqq8rMzJQkzZ8/n2t01IPHH39c27dvlyQ9+OCDmjFjhv75z3/WuH9AQICioqJcrnPo0CHNnDlTsbGxGjlypPr06aOwsDA5HA4dO3ZM77//vtkPPz8/rVixwit39GhuZs+erdLSUk2YMEGDBg1St27dFBgYqMLCQu3atUvJycnmsu0HHnjA7a/pPfjgg5o8ebLWrl2rTZs2afjw4Zo7d64iIiJ0+PBhLV68WP/6178kSa+++qrXLvLb3J0/f15btmyRJN1111360Y9+ZEm7zG/v2LNnj06dOmX+d8VclW5cM6/yp2mSNG3atCptePO4O3/+fK1bt04nTpzQggULdOrUKU2ePFmBgYFKTU3Vyy+/LIfDocDAQP3xj390u05T5umYZ2VlacSIEeaFMhctWqTWrVvXepwPDw+v8Va9tVmyZImeeOIJjR8/Xg888IB69OihkJAQXbhwQfv27dOf//xn83X/9ttvV1JSkss1mjpPx/vMmTOKjY3VoEGDNHbsWN1zzz3mWJ4+fVobNmzQhg0bzE/kf//737u8SreyxYsX669//asKCgr0+OOPKyMjQ2PGjJEkbdmyRcuWLZN04+vAixYtcrtOU2XFa3pla9euNW9tbfXqHea3+6w612q2x+96jY+aoU2bNhmhoaFmgvf9n6ioqBo/tXVmBY9hGEZZWZnx05/+tMYakowZM2YYZWVl9fQsm7fa/u7V/XTt2rXadur6hL/y47X9hIWFGRs3bqzfJ92Mde3a1alxmDBhgnH+/Plq23BmBY9h3PgkYdSoUTXW8PX1rfX3Yb0333yz1k9kasL8bhwqf+rmzE9NrDjuOvMJoGEYxsmTJ41evXrVWCc0NNTYvHmzJ3+WJs3TMXd2blb+qel1ua5P+Cs/XttPTExMjatGmjtPx7vye+/afoKCgozk5ORa++LMCh7DMIz9+/cbHTp0qLFWhw4djP3793v6p2mSrHpNr3DfffcZkgw/Pz8jPz/fpb4wv+uPq6/BNZ1rGUbzPH6zgsdiY8eO1T/+8Q8tX75cW7duVW5urgICAtSzZ0899thjmjVrloKCgjyq4evrq5SUFE2YMEErVqzQwYMHVVhYqPbt26t///5KTEz06kVAUT9GjRqllJQUpaenKzMzU999953OnTsnwzDUrl073XPPPXrkkUc0bdo0hYaGNnR3m6y//OUvSktLU3p6uk6fPq3CwkJdvHhRISEh6ty5s+6//35NnTpVgwYN8rhWYGCgtm7dqg8++ECrVq3SV199paKiIv3gBz/QkCFDNGvWLEvqwHnvvvuupBuraJ544gnL2mV+24s3j7s9e/ZUZmam/vSnP2n9+vU6deqUrl+/rs6dO2vUqFGaM2eOunbtakktNKzf//732rlzp9LT03X8+HEVFhaqqKhIQUFBioiI0H333afHH39ccXFxXE+xntx777167733lJ6eroyMDOXn56uwsFAOh0Nt27bVnXfeqYceekgzZ850a5VWde677z4dPnxYy5cv18aNG3XmzBlJNy4KGx8fr7lz55q3ZEf9OXnypL744gtJ0vDhw9WhQwdL22d+Nw7N8fjtYxg1XAUIAAAAAAAAtsBdtAAAAAAAAGyOgAcAAAAAAMDmCHgAAAAAAABsjoAHAAAAAADA5gh4AAAAAAAAbI6ABwAAAAAAwOYIeAAAAAAAAGyOgAcAAAAAAMDmCHgAAAAAAABsjoAHAAAAAADA5gh4AAAAAAAAbI6ABwAAAAAAwOYIeAAAAAAAAGyOgAcAAAAAAMDmCHgAAAAAAABsjoAHAAAAAADA5gh4AAAAAAAAbI6ABwAAAAAAwOYIeAAAAAAAAGyOgAcAAAAAAMDmCHgAAAAAAABsjoAHAAAAAADA5gh4AAAAAAAAbI6ABwAAAAAAwOYIeAAAAAAAAGzu/wGQ0EnAT4GycAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "height": 434,
+       "width": 572
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.scatter(*zip(*fp.points, strict=True), s=600, color=\"cadetblue\", zorder=1)\n",
+    "plt.scatter(*zip(a, b, strict=True), color=\"red\", ec=\"k\", zorder=2)\n",
+    "plt.xlim(0, 20)\n",
+    "plt.ylim(0, 20)\n",
+    "plt.title(f\"Closest pair is {dist:.2} units apart.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfcae4e4-0093-4776-8174-d0e6396afc2b",
+   "metadata": {},
+   "source": [
+    "Add 4 more 2D points with the `+=` operator and query again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "95725979-b1e1-4561-a0cb-817bc012a6b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.124743Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.124670Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.127973Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.127776Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.124736Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2.23606797749979, ((9, 10), (7, 11)))"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for p in range(4):\n",
+    "    fp += tuple(*random_points(p, (2), 1))\n",
+    "\n",
+    "dist, (a, b) = fp.closest_pair()\n",
+    "dist, (a, b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb398691-723d-41d0-a59d-b7ea92cb3218",
+   "metadata": {},
+   "source": [
+    "The closest pair has been updated!\n",
+    "\n",
+    "Vizualize the current set.\n",
+    "\n",
+    "* 4 initial points in `\"cadetblue\"`\n",
+    "* 4 additional points in `\"goldenrod\"`\n",
+    "* Current closest pair in `\"red\"`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "b29156fa-5ec2-4e93-ab3a-317b4a298ceb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.128421Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.128356Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.222337Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.222104Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.128414Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABHgAAANlCAYAAAAHHU6IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy80BEi2AAAACXBIWXMAAB7CAAAewgFu0HU+AAC05klEQVR4nOzdd3xUVf7/8fekFyAhCSWhJYJJ6CAEEdAALiAKUlQQC6C4ukW3W3b1h7I2LKuu7urKgoLIKlYUFAWRIk0I0gkJIJGEBEkhlBTS7u8PYL4JpEySydy5yev5eOTBndwz53xmkgyZd84512YYhiEAAAAAAABYlofZBQAAAAAAAKB+CHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAoBGZPn26bDabbDab5s+fb3Y5aCTmz59v/76aPn26aXUMHTrUXseaNWtMqwPWk5KSYv/eiYyMNLscAAAahJfZBQAApFOnTmn58uVauXKlEhISlJmZqaysLPn4+Khly5aKjo5WXFycbrzxRl111VVmlwugnLy8PK1evVqrVq3SDz/8oOTkZOXk5MjLy0thYWHq27evRo8erTvuuEOBgYFOH7+oqEjr1q3TqlWrlJCQoP379ysrK0uSFBoaqp49e+oXv/iF7rrrLoWEhDh9fAAA4B6YwQMAJsrPz9czzzyjyMhI3XrrrZo3b5527typ9PR0FRUV6cyZM0pNTdWqVas0e/ZsDRo0SDExMXrvvfdkGIbZ5TcJzIpCde644w61bt1aY8eO1SuvvKJ169bp2LFjKioqUn5+vo4cOaLPPvtMv/rVrxQZGalPPvnEqeM/9NBDatOmjUaMGKHZs2frm2++UVpamgoLC1VYWKijR4/qq6++0l/+8hd17NhRb7zxhlPHb2wiIyPtP+8pKSlml4N6YuYWgKaGGTwAYJIjR45o7Nix2rVrV4XPd+zYUb169VKrVq1UWlqqY8eOaefOnfr5558lScnJybrtttuUmpqqhx56yIzSAZz30Ucf6ezZs/bbLVu21IABAxQRESHDMJSYmKgtW7bIMAxlZWXppptu0htvvKFf/epXThn/888/V25urv12YGCgrrzySrVr104+Pj46cOCANm3apOLiYuXl5ek3v/mNjhw5omeffdYp4wMAAPdBwAMAJkhJSdFVV12lY8eOSZJsNpumTJmiv/3tb+revfsl7Q3DUEJCgl577TUtWrRIZWVlys/Pd3XZaKKmT59u6t47F7jrvjsBAQGaMmWK7r77bg0cOFAeHhUnSO/du1d33HGHduzYIUm6//77NXjwYPXs2dMp43t5eemmm27SjBkzNGzYMHl5Vfz17siRI7r77ru1atUqSdLs2bN1zTXXaPTo0U4Z3woiIyOZ9QgAaPRYogUALlZUVKRbbrnFHu74+fnpk08+0aJFiyoNd6RzAVBcXJzeeecd7dy5Uz169HBlyQCq8MADD+jHH3/U3LlzNWjQoEvCHUnq3r27vv32W3Xq1EmSVFpaqmeeecYp4996661KSkrS+++/rxEjRlwS7kjnZgV+8cUXiouLs3/u73//u1PGBwAA7oOABwBc7Pnnn1dCQoL99oIFCzR+/HiH79+jRw9t3rxZI0aMaIDqANTGCy+8oDZt2tTYrmXLlnr44Yftt7/88kunjP/EE0/osssuq7Gdr6+vZs2aZb/9/fffKzs72yk1AAAA90DAAwAuVFBQoFdffdV+e+LEiZo0aVKt+wkMDNTgwYPrXc+ZM2f06quvatSoUWrfvr38/PzUsmVL9ejRQ/fff7++//57h/tKTU3VrFmzdM0116hNmzby9fWVj4+PQkND1bt3b912221644037DOXqmMYhj799FNNmzZN0dHRCgoKkp+fnzp06KDx48drwYIFKikpcaiu/fv366GHHtLAgQMVFhYmHx8f+fn5qXXr1urXr5/uuusuLViwQCdOnKhwvwubrS5YsMD+ubvuusu+YWf5jyeeeMLh56m8qjYAXbVqlaZMmaLOnTvL399frVq10tVXX61//etfFfZ7qc7x48f19ttva9q0aerbt69CQkLk7e2t4OBgxcbG6q677tLXX3/tUF+OXCZ9zZo19jZDhw61f/7LL7/UlClTdPnll6tZs2ay2Wx65ZVXHBr3Yo5eJr24uFjvvvuuJk6cqMsuu0zNmjWTl5eXmjdvri5dumjUqFGaOXOmtmzZUqc66qr8z+ypU6eUk5Nj2viGYeinn36qd5+13YTcke+lqtp8+umnGjt2rDp27ChfX1+1bt1aI0eO1Lvvvlvj8qvqNtstf678cxIVFVXpz3tl33vOfP1zxE8//aQ33nhDU6ZMUY8ePRQUFCRvb2/7VdN+/etfa/PmzQ71VdnXMDs7W88995wGDBigVq1ayd/fX507d9a9996r7du3O9RvWVmZvvvuO82cOVMjR45Ux44dFRAQIF9fX4WHh2v48OF6+umn7Vd8q0n5r8EFO3fu1O9//3v16NFDISEhstlsGj9+vP17KCoqqsJzVtnXs3x/AGB5BgDAZd555x1Dkv1j/fr1Tu1/2rRp9r7ffvvtatsuXbrUaNu2bYV6Kvu47bbbjLy8vGr7evPNNw1/f/8a+5JkDB48uNq+du7cafTp06fGfmJiYoy9e/dW29fjjz9ueHp6OlTX7bffXuG+nTp1cuh+kozHH3+82jqqcvjwYXsfnTp1MoqKiox777232rG6du1qJCUlVdvvP//5T4cf9/Dhw42srKxq+3v77bft7adNm1Zpm9WrV9vbxMfHG7m5ucaECRMqHfPll1+u0/MVHx9v72P16tWVtklKSjK6du3q8NfuwIEDdaqlLnbt2lVh7OPHj7tsbMMwjFOnTlUYf8uWLfXuszavOYbh2PfSxW1yc3ONG2+8sdqv43XXXWfk5+dXOe7FP2tVnXPk4+LvPWe+/jniL3/5i2Gz2Rwa79Zbb63x9fvir+HGjRuNiIiIKvv09PSs8TWvqKjIaNeunUM1BgYGGgsXLqzxcZe/j2FU/fo+bty4Ct9DjnwAQGPBJssA4ELffvut/bhjx45OmYVTF4sXL9btt9+u0tJSSZKnp6eGDBmiLl266MyZM/ruu++Unp4uSfrf//6nw4cP69tvv5Wfn98lfS1ZskT33Xef/XaLFi101VVXqX379vLy8tLJkyeVnJysPXv2qKioqNq61q1bp7Fjx+rUqVOSJG9vb8XFxenyyy+Xt7e3UlJStH79ehUWFiopKUmDBg3Spk2b1LVr10v6+uc//1lhSUpYWJgGDhyo8PBw2Ww25eTkaP/+/UpMTLQ/D+VNmzZN2dnZWrVqlfbv3y9JuvbaaxUbG3tJ2wEDBlT7uBz18MMPa86cOZKkXr16qU+fPjIMQ9u2bdO+ffskSYmJiRo+fLg2bdqkDh06VNpPenq6/TFddtll6tq1q1q1aiU/Pz/l5uZq9+7d2rt3r6Rz35O/+MUvtHnzZvn6+jrlcRiGoTvuuEPLli2TzWZT//791a1bNxmGoT179jTYX8xPnz6tX/ziF0pNTZUkeXh4qG/fvuratauaNWum/Px8HT16VDt37nR41oAz7d69237s7++vsLAw08aXVOX3jzspKSnRTTfdpFWrVsnHx0eDBg1S586dVVhYqO+++05HjhyRJH311Vf605/+VKfLwLdo0UK//e1vJUnvvPOOTp8+LUmaOnWqmjdvfkn7du3a2Y+d+frnqNTUVBmGIZvNppiYGMXExCg0NFTe3t7Kzs7W9u3bdejQIUnS+++/r1OnTtl/Fmvy008/6U9/+pNOnDihZs2aafjw4WrTpo3S09O1evVq5efnq7S0VLNmzVJZWVmVezmVlpbq6NGjkqRmzZqpe/fuuuyyy9SiRQsVFxcrLS1Nmzdv1qlTp5SXl6c777xT3t7emjx5skPPwQsvvGB/fe/cubMGDBiggIAApaSkyNvbW127dtVvf/tbnT59Wu+8844kqXnz5po6dapD/QOAZZmbLwFA09K5c2f7XwxvueUWp/fvyF/TDx48aDRr1szebsCAAZfMYigtLTX+8Y9/GB4eHvZ2DzzwQKX9lZ9tc//991f51+LTp08bH3zwgfHwww9Xej4jI8No3bq1va+pU6ca6enpl7Q7duxYhZkhPXv2NEpKSiq0KS4uNsLCwuxtnn32WaOoqKjScbOzs4233nrLeO655yo9X9sZCrVRfuaAt7e3IckIDQ01vv7660vafv7550aLFi3s7UeNGlVlv/PmzTNee+01Iy0trco2O3fuNPr372/v78knn6yybW1n8Hh5edm/Nrt27bqkbWFhYZVjVaemGTyvvPKK/Xy3bt2M/fv3V9pPWVmZsWXLFuPXv/61ceTIkTrVUhcjRoyw13fDDTe4bNwLfvnLX9rH7969u1P6bOgZPL6+voYkY/To0Zd8PxcXFxt/+ctf7G1tNptx+PDhSvusbgZPeeVn7lXVV3nOev2rjeeff954++23jczMzCrbrFu3zujSpYu9tupmyJT/Gvr4+BjSuRmNJ0+erNAuJyfHmDhxor2th4eHsWHDhkr7PHv2rHHXXXcZq1evrvK1t7Cw0Hj++eftrxfBwcHG6dOnq6zzwrgXXmOCgoKMTz/9tNJ+L3D06w4AjQUBDwC40IVfZCUZTzzxhNP7d+TN1tSpU+1tunTpYuTm5lbZ30svvVThl/kff/yxwvnTp0/bz3fo0MEoKyurc+133323va/f/e531bYtKSkxhg8fbm///vvvVzi/e/dupy2JcFXAU9MbJsMwjJUrV1Zov2rVqnqNn5uba1+mFx4efklQdkFtAx5JRtu2bat9A1oXNQU8N910k/38ypUrnTp2fS1durTC8/Pll1+6dPzt27dXWM7y+uuvO6Xfhg54JBlXX321UVxcXGnbsrIyIy4uzt529uzZlbZriIDHma9/DeHw4cOGn5+fPcivSvmvoSTj+uuvN0pLSyttW1xcbAwdOrTC16a+Zs+e7dD35cWvlWvXrq2xbwIeAE0NmywDgIucOnWqwsbAwcHBLq8hNzdXixcvtt9+/vnnFRQUVGX73//+9/ZLt5eVldmXD11wYSmVJIWGhtZ56U1mZqbeffddSVLbtm313HPPVdve09NTTz/9tP32okWLqqyrVatWdarJDLfffrsGDRpU5flf/OIXmjhxov32f//733qNFxQUpAkTJkiSMjIy7MvAnGHmzJkuX4Lkrl/3jIwM3XvvvfbbI0aM0OjRo102/oUlMBeW7XXr1k333HOPy8avr1deeaXSy79L5zbeveuuu+y3XblxtrNe/xpKZGSkhg0bJknaunVrhXqrYrPZ9Oqrr8rDo/K3CF5eXhUuFPDdd98pKSmpXnWW//p98803Dt3n5ptv1jXXXFOvcQGgMWIPHgBwkQv7OlzQrFkzl9ewceNG+1WYwsLCNHbs2Grbe3h46O6779af//xnSdLq1asrnA8LC5Ofn58KCwu1Z88ebdiwoU77Cn3zzTf2/SkmTpxY6V4/F7vyyisVGBiovLw8rV+/vsK58nuLrF69WsnJyYqOjq51Xa7myP4Q06ZN0yeffCLp0q9HZY4fP67NmzcrMTFRJ06cUF5eXoUrDiUkJNiPd+zYoZ49e9ah8ks5upeGM5X/uv/nP/+p034szlZUVKSbb75ZGRkZks4FAY5cbcpZDMPQXXfdpT179kg6d7n09957T97e3i6roT4uu+wyXXHFFdW26du3r/04JSWlgSv6P856/auPI0eOaMuWLUpOTlZubq4KCgoq/HwfPnxY0rnvg507d+rqq6+utr8LexxVp2fPnurbt6/9alqrV69WTExMle3Lysq0bds27dixQ2lpaTp16pSKi4srbbtjx45qx77g1ltvdagdADQ1BDwA4CIXb9Z55swZl9dQ/vK2AwYMqPKv4uWVf8Oyfft2++aekuTj46Px48fr/fffV0lJiYYPH67Jkyfb/7rq6CylTZs22Y937dql+++/38FHdM6F4CIwMFDSuTf6AwcO1ObNm3Xy5En169dPd955pyZMmKDBgwcrICCgVv27gs1m05VXXllju6uuusp+/PPPPysjI0Ph4eGXtNu3b58efvhhLV++vNJNpCvjrI2Ho6KiFBIS4pS+amPSpEl66623JJ0LeLZt26Zp06Zp1KhR6tKli8vrMQxD06ZN08aNGyWd2zT8vffeU0REhMtqeOSRR/Thhx/ab//nP/9Rr169XDZ+fTkSOIaGhtqPHZml4izOev2ri02bNumRRx7Rd999V+Ml4i9w5Oe7/OtLTe0u/H9S1WXTS0pK9Oqrr+rll19WWlqa02qUpH79+jnUDgCaGgIeAHCRFi1ayMvLy75MKzc31+U1ZGZm2o87derk0H0iIyPtx0VFRTp9+rRatGhh/9zLL7+sbdu26cCBAyoqKtLChQu1cOFCeXh4qHv37rr66qvtS1KqukrThSt2SdL69esvmZHjiBMnTtgDHkmaN2+ehg8frp9//llnzpzRG2+8oTfeeENeXl7q06ePrrnmGo0aNUrXXnutPD09az2es7Vs2bLSK/Zc7MLVsAoLCyWd+5peHPB8/fXXGjdunH22lqMunmVWV2Ytjxo1apQeeOABvfbaa5LOLUvZunWrJKlNmzYaMmSIhg4dqvHjx6t9+/YNXs/999+v999/X9K52XALFizQiBEjGnzcC55//nk9//zz9tvPPfecpk+f7rLxnaG6JaQXlJ+NVNXMkIbijNe/2nrrrbd0zz33OBzsXODIz3fHjh0d6qt8u/L/r1xw9uxZ3XjjjVqxYoXjBcrx1yB3WoIJAO6EPXgAwIXKhyrO3O/EUeVnDZUPQ6pzcbuLfwFv27atEhIS9Nhjj6lNmzb2z5eVlWn37t16/fXXNWHCBIWHh2v27NmVziY5efJkbR5GpcrvbySd22dk586deuCBByq8SSwpKVFCQoJeeukljRo1Sp06ddLcuXPrPX591WZWUfmvycVfj8zMTE2ePNke7nTq1EnPPvus1q9fr/T0dOXn56usrEzGuQst6PHHH7fft6ysrJ6P4hx/f3+n9FMXr776qj755JNLLl3/888/6+OPP9YDDzygjh076uabb7ZfYrsh/PWvf9Xrr79uv/3vf/9bU6ZMabDxLvbmm2/q4Ycftt9+5JFH9NBDD7lsfGdxt31tLuaM17/a2Ldvn+677z57uNO9e3f985//1JYtW/Tzzz/bl2hd+Jg2bVqFmmri6OtQda9BkjRr1ix7uGOz2TR58mR98MEHSkxM1MmTJ1VUVFShzgscDa3MfI0BAHdGwAMALjRkyBD78ffff+/y8cvv+5OXl+fQfS5uV9kskxYtWujJJ5/U0aNHtXnzZr3wwgsaP358hU12T5w4ob/+9a+66aabLvklvvybhZdeeqnCL/6OfpSfaXRBmzZt9Oqrr+rnn3/WmjVr9OSTT2r06NEVZiAdPXpUv/zlL/W73/3OoeejoeTn5zvctvzX5OKvx3//+197YNa7d2/t2rVLjzzyiAYPHqzw8HD5+/tXeNPsrFk77mTChAn6/vvv9dNPP2nBggW677771K1bN/t5wzD08ccf64orrlBycrLTx3/66ac1e/Zs++3nnntOv/rVr5w+TlXeffdd/frXv7bf/vWvf61nn33WZeNXx1khojup7+tfbbzyyiv2MHvUqFH64Ycf9Lvf/U5xcXFq3br1JfuX1fbn29HXoepeg86ePWufRSdJ8+fP1/vvv69bbrlFsbGxatGiRYVZV43xNQgAzELAAwAuNHz4cPvxTz/9ZN+bw1XKT2t3dPZC+U1LfXx8ql1G5OnpqSuvvFJ/+ctf9Omnn+rnn3/Wd999pxtvvNHe5rPPPtPHH39c4X7l//J97Ngxh+qqDV9fX8XHx+uxxx7Tl19+qaysLC1fvrxC4Pbaa6/Zl/OY4cSJEw7ty5SVlWVfniXpkitVrVq1yn782GOPVQizKvPTTz/VslLr6Nixo6ZOnar//Oc/2rt3r44cOaJZs2bZZylkZ2frT3/6k1PHfOWVV/TYY4/Zbz/22GMunTnz8ccfa/r06fYQ4c4779S///3vBhuv/Bv1i2fRVcYZs/XcVV1f/2qj/M/3U089JR8fn2rb1/bn29H/F1JTU+3HF78Gbdmyxf5a1r179xo3j2/Mr0EA4GoEPADgQrfcckuFX4Zfeukll45f/mozW7ZscWi5QPkQqm/fvrVaMuHh4aEhQ4ZoyZIlFfYe+fzzzyu0K7+58IYNGxzuv668vb113XXX6ZtvvlGPHj3sn1+6dOklbV21RMQwDIdmdZXfkLpNmzaXbNhbfj+jmjaoLS0tdcnz7S46dOigmTNnas6cOfbPrVixotZ7FVVlzpw5+uMf/2i//fvf/15PPvmkU/p2xBdffKEpU6bYf64nTpyot99+u0G/h8sHiNnZ2TW23717d4PV4gzOfK4cff2rjdr8fJ88eVK7du2qVf+bN292qF3516GLr3JWmxolad26dQ5WV3vuvsQPAJyNgAcAXMjf37/CUqCPP/64Tn/NzcvLq9Psn0GDBtk3+szMzNQXX3xRbfuysjK9/fbb9tvlZyDVhs1mq3BJ9p9//rnC+VGjRtmv6LVx40bt3LmzTuPUlq+vr0aOHFllXZIqLHlo6A1cFy5cWGObd955x348bNiwS857ePzff+01LbdYsmRJg8yYcnflZ1QUFxcrJyen3n2+++67FZZhzZgxQy+//HK9+3XUt99+q5tvvtn+PTp69Gi99957Db6BePmlkTVd4rqwsLDSENWdNMTPe02vf7VRm5/vuXPn1voxbNiwwX5p9ars3btXP/zwg/320KFD61xjWVlZhcDV2Vz5+g0A7oCABwBc7KGHHqrwF88777yzVm969uzZo4EDB9b66iSSFBwcrMmTJ9tvP/jgg9Xuf/Cvf/3L/hd3Dw8P3XvvvRXOnz59WkVFRQ6NXX5Kf+vWrSuca9eune644w5J52ayTJ061eHLHZeVlV1yFZcTJ044vNdHdXVJFS/BfPToUYf6rKt333232lk8q1evrhAI3nPPPZe0ueyyy+zH1c0UyMzMrDDbpDFw9BLL5b/mHh4eFb7GdfHJJ59UWBY1ZcoUzZkzx2WzBzZu3Kgbb7zRvnQvPj5eH3/8cY3Ld5yh/Oy7ZcuWVfs1mDlzpsNfI7PU5ufdWa9/teHoz/eBAwc0a9asWvdvGIZ+//vfV7lPUGlpaYU/UgwZMkSxsbFV1rh27dpql+W98MILDRroBwcH2wOnzMxMQh4AjR4BDwC4mK+vrz788EP7L/kFBQUaP368pk6dqsTExErvYxiGtm7dqmnTpql3797as2dPncefOXOmfbPl5ORkjRo1Sj/++GOFNmVlZfrnP/9ZYX+S3/72t5dsZLxt2zZFRkbqiSeeqPKqYKWlpVq8eHGFTTdHjx59Sbunn37afrnvXbt2acCAAdWGWGlpaXr55ZcVExOjxYsXVzj32WefKTo6Wi+++GKFPYTKO3v2rP71r3/po48+qrau8ku4PvvsM4ff0NWWt7e3SktLNWbMGH3zzTeXnP/iiy80YcIE+xuvESNG6Nprr72kXfmZAs8++6zefffdS9r88MMPio+PV2pqqsNXU7OCq666SrfddpuWL19e5dcpOTm5wpWFrr322noFIV999VWFZVHjxo3TO++8U2EWQ11Mnz5dNptNNput0g3EL9i+fbuuv/56+6a3V155pZYtW+ayqwzFxcWpc+fOks5dpW/KlCk6ceJEhTb5+fl68MEH9cILLzjtUuENpfzP+4cfflhtW2e+/jmq/M/3n/70J3399deXtFm1apWGDh2q06dP1/rn28fHR0uXLtX06dMvCf9PnDihKVOm6Ntvv5V0bmZSZZt39+3bV+3atZN0bpnYLbfcUmHZlnTu9XfmzJl65JFHGvQ1yNfXV5dffrmkczN4lixZ4tD9HP35AwB342V2AQDQFF122WX6/vvvNXbsWO3Zs0dlZWVauHChFi5cqMjISPXq1UthYWEqLS3VsWPHtGPHjkum9Ve32XF1OnfurLlz5+r2229XaWmpNm3apJiYGF199dXq3Lmzzpw5o++++67CX68HDhyo559/vtL+MjIyNGvWLM2aNUtt27ZVnz591LZtW3l5eennn3/Wtm3bKvxyf/XVV+vWW2+9pJ+IiAh99tlnuv7665WVlaWkpCSNGjVK7dq104ABA9SqVSsVFxcrKytLe/bsqXEZwaFDh/Tggw/qwQcfVMeOHdWrVy97qHbs2DFt3ry5wtKc22+/XYMGDbqkn9GjR8vf318FBQXasWOHunbtqqFDhyo4ONg+Q2PkyJEVlnrVRUREhCZMmKBXXnlFI0aMUO/evdWnTx8ZhqFt27Zp79699rbh4eH673//W2k/06ZN0z/+8Q8lJyfr7NmzuvPOO/XMM8+od+/e8vPz0549e5SQkCDp3FW2Ro0aVeXX1mqKi4v13nvv6b333pO/v7969eqlyy67TC1atNCJEyf0448/2h+7dG7J5Isvvljn8bKysjRx4kR7mOTp6alWrVrpD3/4g0P3v/POOyvMgKmLUaNGVZgh0blzZz3yyCMO3ff666/X9ddfX6/xL7zJnzRpkiTpm2++UVRUlK699lqFhYXp2LFjWrdunXJzcxUREaHf/va3evTRR+s1ZkO66aab9Oabb0qSXn/9dW3btk1XXHFFhcuH//rXv7aHWs56/XPUH/7wB82dO1eZmZnKycnRddddpyuuuELdunWTzWbTDz/8YH+tGDVqlFq3bu3Q0s8L/vrXv+qf//yn3nnnHX366acaPny4WrdurWPHjunbb7+tcPWsv/71rxU2qr/Aw8NDTz75pO6++25J0sqVKxUdHa1BgwapU6dOys7O1po1a+xB4Jw5c3T77bfX+TmpyU033aRnnnlG0rnX+fnz56tLly4VNgivz+sAALgVAwBgmtOnTxt///vfjeDgYEOSQx+9e/c2Pv3000r7mzZtmr3d22+/Xe3YS5cuNdq0aVPjeFOmTDHy8vIq7WPz5s2Gl5eXw7XffPPNxqlTp6qtKyUlxbj22msd7rNNmzbGV199VaGPDz/80LDZbA7d38PDw/jNb35jFBUVVVnTG2+8UW1/jz/+eLWPqSqHDx+299GpUyejqKjImDFjRrX1xsTEGImJidX2m5SUZFx22WXV9jN48GAjLS3NePzxx2t8HG+//ba9zbRp0ypts3r1anub+Pj4Oj0fNYmPj7ePsXr16kvO9+jRw+Hvm6ioKGPDhg31qqf8168uH9X9jJb/We7UqVOV7eozfl2/bysza9asGr9v9+zZ49D3kiNtyrv456iubS6YMmVKtY/lwvdeQ7z+OWLjxo1GWFhYtWONHz/eyM3Ndej/hIvbbNiwwQgPD6+yb09PT+PRRx+tsc6//e1v1dbo5+dn/Oc//zEMo+L3cVUcaVOZ3NxcIzY2ttpaqntOavp+AQB3wgweADBRs2bN9P/+3//T7373O3355ZdauXKltm3bpuPHjysnJ0c+Pj4KCQlRbGysrrzySo0fP/6SK5bU1ZgxY3Tw4EG99dZbWrZsmfbu3ausrCz5+/srIiJCw4YN09SpU6udYXDllVfq+PHj+uabb7R+/Xpt375dhw4dUnZ2tkpLS9WiRQt17txZAwcO1B133KEBAwbUWFenTp30zTffaNOmTfrwww+1bt06paam6sSJE/Ly8lJoaKguv/xy9e/fXyNHjtTQoUPtGzRfcPPNNysjI0MrVqzQhg0btHPnTv3444/Kzc2VJAUFBSk6OlpDhgzR1KlT1a1bt2pr+tWvfqWePXvqzTff1Pfff6+jR48qPz+/yn0q6srb21tz587VLbfconnz5mnr1q3KyMhQYGCgunbtqsmTJ+vee++tcZlLdHS0tm/frn//+9/65JNPlJSUpKKiIrVt21Y9e/bUbbfdpkmTJjX4BryutmPHDm3evFmrV6/Wli1blJSUpPT0dOXn5ysgIMA+w+LGG2/UpEmT3H65kJXMnDlTI0aM0GuvvabvvvtOx48fV4sWLdSlSxfdeuutmjFjhpo1a6atW7eaXWqNFi1apDFjxui9997Tjh07lJWVZd/fqLyGeP1zxFVXXaW9e/fqlVde0dKlS+1LbMPDw9WvXz/dcccdFZZy1dagQYO0c+dOzZkzR59++qlSUlJ05swZRUREaPjw4frNb37j0P9DTz/9tEaPHq1//etfWr9+vTIzM9W8eXO1b99e1113nWbMmGFfPtWQgoKCtHXrVr3++uv64osvlJiYqNzcXPbjAdAo2Qxn/3YKAAAckpKSoqioKEnngq2q9gsCgIYyffp0LViwQJL09ttva/r06eYWBACoMzZZBgAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAi2vQy6QnJCToyy+/1Pr167Vv3z5lZmbK29tbERERGjx4sGbMmKEhQ4Y43N/y5cs1Z84cbd26VZmZmWrVqpXi4uJ07733avTo0U6rOz8/X//617/04Ycf6tChQzp79qw6dOigG264Qb/73e/UqVMnp40FAAAAAABQXw0W8FxzzTX67rvvamw3depU/fe//5WPj0+VbcrKynTvvfdq3rx5Vba555579Oabb8rDo36Tkg4ePKjrr79eBw4cqPR8ixYttGjRIo0ZM6Ze4wAAAAAAADhLgy3RSk9PlyRFRETo97//vT766CNt2bJFmzZt0ksvvaR27dpJkt555x1Nnz692r4effRRe7jTt29fvffee9qyZYvee+899e3bV5I0d+5cPfbYY/Wq+fTp07rhhhvs4c4vf/lLrVq1Shs3btTTTz+tZs2a6dSpU5o8ebJ27NhRr7EAAAAAAACcpcFm8IwZM0ZTp07VTTfdJE9Pz0vOZ2VlafDgwUpOTpYkrV27Vtdcc80l7ZKTk9W9e3eVlJSof//+Wrdunfz9/e3n8/PzFR8fr4SEBHl5eSkxMVFdunSpU80zZ87Uk08+KUl6/vnn9eCDD1Y4v3HjRsXHx6ukpETx8fFas2ZNncYBAAAAAABwpgabwbNs2TJNmjSp0nBHksLCwvSPf/zDfvujjz6qtN0rr7yikpISSdJrr71WIdyRpICAAL322muSpJKSEr388st1qre4uFivvvqqJKlr167685//fEmbQYMGacaMGZLOBVJbt26t01gAAAAAAADOZOpVtIYNG2Y/PnTo0CXnDcPQZ599JkmKjY3VwIEDK+1n4MCBiomJkSR99tlnqsukpNWrV+vkyZOSpGnTplW5l0/55WSffvpprccBAAAAAABwNlMDnrNnz9qPK5vpc/jwYftePvHx8dX2deH80aNHlZKSUuta1q9ff0lflenfv78CAgIkSRs2bKj1OAAAAAAAAM7mZebga9eutR937dr1kvP79u2zH8fGxlbbV/nziYmJioqKqlUtjo7l5eWlLl26aNeuXUpMTKzVGGlpadWeLyws1P79+9WmTRu1atVKXl6mfnkAAAAAAGiUSkpKlJmZKUnq2bOn/Pz8TK6o/kxLEMrKyjR79mz77UmTJl3Spnwg0r59+2r769Chg/04NTW11vVcGCswMFDBwcE1jrVr1y5lZmbq7Nmz8vX1dWiM8jUCAAAAAADzbdmyRXFxcWaXUW+mLdF6+eWXtWXLFknSxIkT1a9fv0vanD592n7crFmzavsLDAy0H585c6bW9VwYq6ZxnDEWAAAAAACAM5kyg2ft2rV65JFHJEmtW7fWG2+8UWm7wsJC+7GPj0+1fZafRVNQUFDrmi6MVdM49RmrpplFqampGjRokKRzCWJ4eLjDfQMAAAAAAMdkZGRowIABkqRWrVqZXI1zuDzg2bt3ryZMmKCSkhL5+fnpww8/VOvWrSttW34NXFFRUbX9lt+w+eJLqTviwlg1jVOfsWpaZlZeeHh4rdoDAAAAAIDaayz737p0idbhw4c1cuRInThxQp6ennr//fd1zTXXVNm+efPm9uOalkLl5eXZjx1ZZlXVWI4suarvWAAAAAAAAM7ksoAnPT1dv/jFL5Seni6bzaa33npL48aNq/Y+5Wew1HQFqvLLn+qymfGFsfLy8pSbm+vQWK1atXJ4g2UAAAAAAICG4pKAJysrSyNGjNCPP/4oSXrttdc0derUGu/XrVs3+/H+/furbVv+fGWXXHfWWCUlJTp06FCdxwEAAAAAAHC2Bg94Tp48qVGjRmnfvn2SpNmzZ+u3v/2tQ/eNiopSRESEpHMbM1dn3bp1kqR27dopMjKy1nUOGTLEflzdWAkJCfYlWoMHD671OAAAAAAAAM7WoAFPfn6+brjhBv3www+SpEcffVQPP/yww/e32Wz2ZVz79+/X5s2bK223efNm+6ybcePGyWaz1brWoUOHKigoSJK0YMECGYZRabv58+fbjydMmFDrcQAAAAAAAJytwQKeoqIiTZgwQRs2bJAk/f73v9dTTz1V637+8Ic/yNPTU5L0wAMPXHJZ8oKCAj3wwAOSzu18/Yc//KHSfqZPny6bzSabzaY1a9Zcct7Hx0e/+93vJEmJiYl68cUXL2mzadMmzZs3T5IUHx+vuLi4Wj8eAAAAAAAAZ2uwa4FNmTJFK1askCQNHz5cM2bM0J49e6ps7+Pjo+jo6Es+Hx0drQcffFCzZ89WQkKCBg8erIcfflidO3fWoUOH9Nxzz2n79u2SpAcffFCXX355nWt+8MEHtXjxYiUnJ+uhhx7SwYMHdeutt8rf31+rV6/WM888o5KSEvn7++uVV16p8zgAAAAAAADOZDOqWotU345ruUyqU6dOSklJqfRcWVmZfvnLX+qtt96q8v4zZszQnDlz5OFR+aSk6dOna8GCBZKk1atXa+jQoZW2O3jwoK6//nodOHCg0vMtWrTQokWLNGbMmKofTB2lpaXZrwCWmppa4SpiAAAAAADAORrj+2+XXSa9Pjw8PDRv3jx98cUXGjdunCIiIuTj46OIiAiNGzdOX375pebOnVtluFMbXbp00fbt2/Xcc8+pf//+Cg4OVkBAgGJiYvTHP/5Ru3btapBwBwAAAAAAoK4abAYPaq8xJogAAAAAALibxvj+2xIzeAAAAAAAAFA1Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACL8zK7AACA+zEMQ7n5+UrJzlZKdo5SsrOVk5en4pJSFZeWqqSsTF4eHvL29JS3l6dCAgMVGRqqyNAQRYaFqWVAgNkPAQAAAGhSCHgAAJKk9NyT2nL4sA5nZetwdpZOFRQ6fN/UnBPamZpmvx3k76/I0FBFhYVqQFSUIoKDGqJkAAAAAOcR8ABAE1ZSVqbtR47o28QkJR475rR+TxYUaGdamnampWnJjp3qGt5Ww2Nj1bdjB3l5sDoYAAAAcDYCHgBogk7k5WlN8gGtTUpWbkFBg4+XmHFMiRnHFBzgr6HR0YqPiWYZFwAAAOBEBDwA0IQUFBXpg4RtWpt8QGWG4fLxc/MLtGTHTn2+c5fioy/XpLj+8vf2dnkdAAAAQGNDwAMATcTe9HS9tX6jsvPyzC5FZYah1UnJ2pV2VHcPGaTuERFmlwQAAABYGgEPADRyBUVFWrx1m9YkJ5tdyiWy8/L0wtcrNTQmWpOZzQMAAADUGQEPADRi7jRrpzprkpK1m9k8AAAAQJ1xKRMAaKSW79mrF75e6fbhzgUXZvMs37PX7FIAAAAAy2EGDwA0MoZh6JMftmvprt1ml1Ini7cmKL+oSBP79pHNZjO7HAAAAMASmMEDAI2IYRj635atlg13Lli6c5f+t2WrDBOu9AUAAABYEQEPADQin/ywXSv3JZpdhlOs3JeoT7bvMLsMAAAAwBIIeACgkVi+Z6/lZ+5cbOnOXezJAwAAADiAgAcAGoG96elavDXB7DIaxOKtCdqXnmF2GQAAAIBbI+ABAIsrKCrSW+s3ml1Gg5q3YYMKiovNLgMAAABwWwQ8AGBxixO2WeZS6HWVfSZPHzTSGUoAAACAMxDwAICF7U1P15qkZLPLcInVScks1QIAAACqQMADABbVFJZmXYylWgAAAEDlCHgAwKI+aAJLsy6WfSZPHyZsM7sMAAAAwO0Q8ACABZ3Iz9fa5ANml2GKtUnJOpGfb3YZAAAAgFsh4AEAC1qblKwywzC7DFOUGobWNdFwCwAAAKgKAQ8AWExJWZnWJDeNjZWrsjopSSVlZWaXAQAAALgNAh4AsJjtR1KVm19gdhmmys0v0I4jqWaXAQAAALgNAh4AsJhv9+83uwS38O3+JLNLAAAAANwGAQ8AWEh6bq4SM46ZXYZb2JeRofTck2aXAQAAALgFAh4AsJAth1PMLsGtbDl82OwSAAAAALdAwAMAFnI4K9vsEtzK4WyeDwAAAEAi4AEAyzAMQykEGhX8ROAFAAAASCLgAQDLyM3P18mCpn31rIvlFhToRH6+2WUAAAAApiPgAQCLYPZO5VKYxQMAAAAQ8ACAVaRk55hdglsi+AIAAAAIeADAMggyKsfzAgAAABDwAIBl5OTlmV2CW+J5AQAAAAh4AMAyiktKzS7BLRWX8rwAAAAABDwAYBEEGZXjeQEAAAAIeADAMkrKyswuwS2VlPK8AAAAAAQ8AGARXh68ZFfGy5PnBQAAAOC3YgCwCG9PT7NLcEs8LwAAAAABDwBYhrcXQUZlCHgAAAAAAh4AsIyQwECzS3BLPC8AAAAAAQ8AWEZkaKjZJbglnhcAAACAgAcALCMyNMTsEtwSAQ8AAABAwAMAlkGQUbnIMJ4XAAAAgIAHACwiOCBAQf7+ZpfhVoL9/dUyIMDsMgAAAADTNWjAc/z4cS1btkwzZ87U6NGjFRYWJpvNJpvNpunTp9d4/5SUFHt7Rz8iIyPrXG9kZGSDjwEAdWWz2ZjFc5FOzN4BAAAAJEleDdl5mzZtGrL7SsXExLh8TABwlaiwUO1MSzO7DLcRReAFAAAASGrggKe8jh07KjY2VitWrHD4Pu3atdPu3btrbPfss8/qf//7nyRp2rRpda7xgnHjxumpp56q8ryPj0+9xwCAuhgQFaUlO3aaXYbbuPKyKLNLAAAAANxCgwY8M2fOVFxcnOLi4tSmTRulpKQoKsrxX8a9vb3Vo0ePatuUlpZqzZo1kqTmzZtrwoQJ9SlZkhQcHFzjuABghojgIHUNb6vEjGNml2K6buHhCg8KMrsMAAAAwC00aMAza9ashuxekvTNN98oPT1dknTzzTfLnw1IATRyw2NjCXgkDY9lSS4AAABwgeWvovXOO+/Yj52xPAsA3F3fjh0UHNC0w+zgAH/17djB7DIAAAAAt2HpgOf06dNasmSJpHNXwLrmmmvMLQgAXMDLw0NDo6PNLsNUw2Ji5Olh6f/CAAAAAKey9G/HH330kfLz8yVJd955p2w2m1P6Xbdunfr06aPmzZsrICBAUVFRmjx5spYsWSLDMJwyBgDUR3xMtDyc9JpnNZ42m66JvtzsMgAAAAC34rKraDWE8suzpk6d6rR+Dx8+XOF2SkqKUlJS9MEHH2jw4MFavHix2rVrV+t+02q4tHFGRkat+wTQNLUMCFB89OVanZRsdikuFx8TrZYBAWaXAQAAALgVywY8R44c0dq1ayVJgwYNUpcuXerdp4+Pj2688UaNHDlSPXr0UFBQkHJzc7Vp0ya98cYbSk1N1YYNGzRixAht2rRJQbW8ekuHDuwXAcB5JvXvp11pR5Wdl2d2KS4T2ixQt/TvZ3YZAAAAgNuxbMDz7rvv2pdLOWv2zpYtWxQcHHzJ54cOHar7779fN998s1asWKHExETNmjVLL730klPGBYC68Pfx0d1DBumFr1eaXYrLzBg8WP7e3maXAQAAALgdy+7Bs3DhQkmSr6+vJk+e7JQ+Kwt3LmjevLk++OADhYSESJLmzJmjoqKiWvWfmppa7ceWLVvqUz6AJqh7RISGxjSNDZeHxUSrW0S42WUAAAAAbsmSM3i2bNmi/fv3S5JuvPHGaoMZZwoKCtKtt96q119/XXl5eUpISNCgQYMcvn/79u0bsDoATdXk/v20u5Ev1QptFqhJcf3NLgMAAABwW5acwdNQmys7olu3bvbjo0ePunRsAKjMhaVajRlLswAAAIDqWS7gKS4u1vvvvy9Jat26ta677jqXju+sS7EDgDN1j4jQ5EY6w+XWuP4szQIAAABqYLmA54svvlB2drYk6bbbbpOXl2tXme3bt89+HBER4dKxAaA6o3t019hePc0uw6nG9u6l63p0N7sMAAAAwO1ZLuApvzxr2rRpLh375MmT9tlDAQEB6t+/cf61HIB1Tbyir0Z062p2GU4xoltXTezbx+wyAAAAAEuwVMCTk5OjL774QpLUs2dP9enTx+H7Dh06VDabTTabTSkpKZec/+qrr1RQUFDl/c+cOaNJkybZZw/NmDFDvr6+taofABqazWbTbQPiNLZ3L7NLqZcbe/fSbQPiWBYLAAAAOKhB1zetX79eBw8etN/OysqyHx88eFDz58+v0H769OnV9vf+++/bL03u7Nk7s2fP1u23366JEydqyJAh6ty5s5o1a6aTJ09q48aN+s9//qMjR45IkmJiYvTEE084dXwAcBabzaabruirAB8fLd6aYHY5tTY5rr9GsywLAAAAqJUGDXjmzp2rBQsWVHpuw4YN2rBhQ4XP1RTwXFie5enpqdtvv90pNZaXk5OjuXPnau7cuVW2iY+P16JFixQSEuL08QHAmUb36K5OISGat36DJS6hHtosUDMGD2ZDZQAAAKAOXLtDcT0cOHBA33//vSRpxIgRatu2rVP7f/HFF7Vq1Spt2rRJSUlJysrKUm5urgICAhQREaErr7xSU6ZM0ciRI1kyAMAyukWE66kJ47R4a4LWJCWbXU6VhsVEa1Jcfy6FDgAAANSRzTAMw+wicE5aWpo6dOggSUpNTVX79u1NrghAY7I3PV1vrd/oVrN5mLUDAAAAMzTG99+W2mQZAFB33SMi9NSEcRoeGyMPk2cietpsGh4bo6fGjyPcAQAAAJzAMku0AAD15+/tralXDdTY3r20NilZa5KTlZtf9RUEnS04wF/DYmJ0TfTlahkQ4LJxAQAAgMaOgAcAmqCWAQEa37ePxvTupe1HUvXt/v1KzDjWYON1Cw/X8NgY9enYQV4eTB4FAAAAnI2ABwCaMC8PD8VFdlJcZCel557UlsOHdTg7WylZ2TpZUPeZPcH+/uoUFqqo0FANiIpSRHCQE6sGAAAAcDECHgCAJCkiOEjj+/ax3z6Rn6+UrGylZJ/7yMnLU3FpqYpLS1VSWiYvTw95e3rK29NTIYGBigwNPfcRFsryKwAAAMDFCHgAAJVqGRCglh0D1LdjB7NLAQAAAFADNkIAAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgCHgAAAAAAAIsj4AEAAAAAALA4Ah4AAAAAAACLI+ABAAAAAACwOAIeAAAAAAAAiyPgAQAAAAAAsDgvswsAzGYYhnLz85WSna2U7BylZGcrJy9PxSWlKi4tVUlZmbw8POTt6SlvL0+FBAYqMjRUkaEhigwLU8uAALMfAgAAAACgiSPgQZOUnntSWw4f1uGsbB3OztKpgkKH75uac0I7U9Pst4P8/RUZGqqosFANiIpSRHBQQ5QMAAAAAECVCHjQZJSUlWn7kSP6NjFJiceOOa3fkwUF2pmWpp1paVqyY6e6hrfV8NhY9e3YQV4erIIEAAAAADQ8Ah40eify8rQm+YDWJiUrt6CgwcdLzDimxIxjCg7w19DoaMXHRLOMCwAAAADQoAh40GgVFBXpg4RtWpt8QGWG4fLxc/MLtGTHTn2+c5fioy/XpLj+8vf2dnkdAAAAAIDGj4AHjdLe9HS9tX6jsvPyzC5FZYah1UnJ2pV2VHcPGaTuERFmlwQAAAAAaGQIeNCoFBQVafHWbVqTnGx2KZfIzsvTC1+v1NCYaE1mNg8AAAAAwIkIeNBouNOsneqsSUrWbmbzAAAAAACciEv8oFFYvmevXvh6pduHOxdcmM2zfM9es0sBAAAAADQCzOCBpRmGoU9+2K6lu3abXUqdLN6aoPyiIk3s20c2m83scgAAAAAAFsUMHliWYRj635atlg13Lli6c5f+t2WrDBOu9AUAAAAAaBwIeGBZn/ywXSv3JZpdhlOs3JeoT7bvMLsMAAAAAIBFEfDAkpbv2Wv5mTsXW7pzF3vyAAAAAADqhIAHlrM3PV2LtyaYXUaDWLw1QfvSM8wuAwAAAABgMQQ8sJSCoiK9tX6j2WU0qHkbNqiguNjsMgAAAAAAFkLAA0tZnLDNMpdCr6vsM3n6oJHOUAIAAAAANAwCHljG3vR0rUlKNrsMl1idlMxSLQAAAACAwwh4YAlNYWnWxViqBQAAAABwFAEPLOGDJrA062LZZ/L0YcI2s8sAAAAAAFgAAQ/c3on8fK1NPmB2GaZYm5SsE/n5ZpcBAAAAAHBzBDxwe2uTklVmGGaXYYpSw9C6JhpuAQAAAAAcR8ADt1ZSVqY1yU1jY+WqrE5KUklZmdllAAAAAADcGAEP3Nr2I6nKzS8wuwxT5eYXaMeRVLPLAAAAAAC4MQIeuLVv9+83uwS38O3+JLNLAAAAAAC4MQIeuK303FwlZhwzuwy3sC8jQ+m5J80uAwAAAADgpho04Dl+/LiWLVummTNnavTo0QoLC5PNZpPNZtP06dMd6mP+/Pn2+9T0MX/+fKfUnZWVpZkzZ6pXr15q0aKFWrRooV69emnmzJnKzs52yhio2ZbDKWaX4Fa2HD5sdgkAAAAAADfl1ZCdt2nTpiG7bxDff/+9xo8fr2PHKs4c2b17t3bv3q25c+dqyZIlGjBggEkVNh2HswjTyjtMuAgAAAAAqEKDBjzldezYUbGxsVqxYkWd+/j6668VERFR5fn27dvXuW9JSk1N1dixY5WZmSkvLy/96U9/0pgxYyRJy5Yt00svvaSMjAyNHTtW27Ztq/d4qJphGEoh0KjgJwIvAAAAAEAVGjTgmTlzpuLi4hQXF6c2bdooJSVFUVFRde4vOjpakZGRzivwIo8++qgyMzMlSf/73/90yy232M9dffXV6tevnyZPnqzjx4/rsccec9qSMFwqNz9fJwua9tWzLpZbUKAT+flqGRBgdikAAAAAADfToHvwzJo1S2PGjLHEUq1jx45p0aJFkqRRo0ZVCHcumDRpkkaNGiVJWrhw4SXLuOA8zN6pXAqzeAAAAAAAleAqWud9/vnnKisrkyTdddddVba7sDl0WVmZPv/8c1eU1iSlZOeYXYJbIvgCAAAAAFSGgOe89evX24/j4+OrbFf+3IYNGxq0pqaMIKNyPC8AAAAAgMpYKuC56667FBERIR8fH4WFhWngwIF67LHHdPTo0Xr3vW/fPklSUFCQ2rZtW2W78PBwtWjRQpKUmJhY73FRuZy8PLNLcEs8LwAAAACAyrjsKlrOsGbNGvtxdna2srOz9f333+sf//iHXnnlFd1333117jstLU2SY1fi6tChg/bu3avU1NQ6jVGVjIyMWvXXmBWXlJpdglsqLuV5AQAAAABcyhIBz2WXXaaJEyfqqquuUocOHSRJP/74oz7++GN99NFHKiws1K9+9SvZbDbde++9dRrj9OnTkqRmzZrV2DYwMFCSdObMmVqNcaF21Iwgo3I8LwAAAACAyrh9wDNhwgRNmzZNNputwufj4uI0efJkLVu2TBMnTlRxcbH++Mc/6sYbb6x2iVVVCgsLJUk+Pj41tvX19ZUkFXAZ7wZTcn7Da1RUUsrzAgAAAAC4lNvvwRMUFHRJuFPemDFjNHPmTElSfn6+5s2bV6dx/Pz8JElFRUU1tj179qwkyd/fv1ZjpKamVvuxZcuW2hfeSHl5uP23pim8PHleAAAAAACXahTvFu+99157CLR27do69dG8eXNJji27yju/0a0jy7nKa9++fbUf4eHhtS+8kfL29DS7BLfE8wIAAAAAqEyjCHhat26t0NBQSarzFbUubK5c00bIkuybK7OnTsPx9iLIqAwBDwAAAACgMo0i4JFU7TIuR3Tr1k2SdPLkSR07dqzKdhkZGTp16pQkqWvXrvUaE1ULOb+RNSrieQEAAAAAVKZRBDyZmZnKysqSJEVERNSpjyFDhtiPq1vmVf7c4MGD6zQWahZ5fkYWKuJ5AQAAAABUplEEPHPmzJFhGJKk+Pj4OvVx4403yuP8xr5vv/12le3mz58vSfLw8NCNN95Yp7FQs8jQELNLcEsEPAAAAACAyrh1wJOSkqLt27dX22bZsmX6+9//LuncVa3uuuuuStsNHTpUNptNNptNKSkpl5xv27atbr/9dknS119/rY8++uiSNh9++KG+/vprSdKdd95Zp8uxwzEEGZWLDON5AQAAAABcyqshO1+/fr0OHjxov31hGZUkHTx40D4b5oLp06dXuJ2SkqJhw4bpqquu0tixY9W7d2+1bt1akvTjjz/qo48+0kcffWSfvfPiiy+qXbt2da736aef1ldffaXMzExNmTJFCQkJGjNmjKRzQdI//vEPSVKrVq301FNP1Xkc1Cw4IEBB/v46WVBgdiluI9jfXy0DAswuAwAAAADghho04Jk7d64WLFhQ6bkNGzZow4YNFT53ccBzwaZNm7Rp06YqxwkICNDLL7+se++9t861SueuirV06VKNHz9ex44d03PPPafnnnuuQpu2bdtqyZIl9qtuoWHYbDZFhoZqpwNXNWsqOjF7BwAAAABQhQYNeOqrX79+evfdd7Vp0yYlJCQoIyNDWVlZKikpUcuWLdW9e3dde+21uueee+wze+rryiuv1O7du/XPf/5TS5YssS/nioqK0rhx4/SHP/zBfkl2NKyoMAKe8qL4vgMAAAAAVMFmXFjfBNOlpaWpQ4cOkqTU1NQmP0soPfek/vbpErPLcBvPThyv8KAgs8sAAAAAAMtrjO+/3XqTZTRtEcFB6hrORtaS1C08nHAHAAAAAFAlAh64teGxsWaX4BaGx8aYXQIAAAAAwI0R8MCt9e3YQcEB/maXYargAH/17djB7DIAAAAAAG6MgAduzcvDQ0Ojo80uw1TDYmLk6cGPKgAAAACgarxrhNuLj4mWh81mdhmm8LTZdE305WaXAQAAAABwcwQ8cHstAwIU30RDjviYaLUMCDC7DAAAAACAmyPggSVM6t9PoYGBZpfhUqHNAnVL/35mlwEAAAAAsAACHliCv4+P7h4yyOwyXGrG4MHy9/Y2uwwAAAAAgAUQ8MAyukdEaGhM09hweVhMtLpFhJtdBgAAAADAIgh4YCmTm8BSrdBmgZoU19/sMgAAAAAAFkLAA0tpCku1WJoFAAAAAKgtAh5YTveICE1upDNcbo3rz9IsAAAAAECtEfDAkkb36K6xvXqaXYZTje3dS9f16G52GQAAAAAACyLggWVNvKKvRnTranYZTjGiW1dN7NvH7DIAAAAAABblZXYBQF3ZbDbdNiBOft7eWrpzl9nl1NmNvXtpQt8+stlsZpcCAAAAALAoAh5Yms1m001X9FWAj48Wb00wu5xamxzXX6NZlgUAAAAAqCcCHjQKo3t0V6eQEM1bv0HZeXlml1Oj0GaBmjF4MBsqAwAAAACcgj140Gh0iwjXUxPGaWhMtNmlVGtYTLSeGj+OcAcAAAAA4DTM4EGj4u/tremDrlJcZCe9tX6jW83mYdYOAAAAAKChMIMHjVL3iAg9NWGchsfGyMPkzYs9bTYNj41h1g4AAAAAoMEwgweNlr+3t6ZeNVBje/fS2qRkrUlOVm5+gcvGDw7w17CYGF0TfblaBgS4bFwAAAAAQNNDwINGr2VAgMb37aMxvXtp+5FUfbt/vxIzjjXYeN3CwzU8NkZ9OnaQlweT5AAAAAAADY+AB02Gl4eH4iI7KS6yk9JzT2rL4cM6nJ2tlKxsnSyo+8yeYH9/dQoLVVRoqAZERSkiOMiJVQMAAAAAUDMCHjRJEcFBGt+3j/32ifx8pWRlKyX73EdOXp6KS0tVXFqqktIyeXl6yNvTU96engoJDFRkaOi5j7BQll8BAAAAAExHwAPo3DKulh0D1LdjB7NLAQAAAACg1tggBAAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsrkEDnuPHj2vZsmWaOXOmRo8erbCwMNlsNtlsNk2fPt2hPvLz8/XJJ5/o17/+teLi4tSyZUt5e3srNDRUV111lZ544gkdO3bMKfVGRkba66vuIzIy0injAQAAAAAAOINXQ3bepk2bet1/165dGjx4sM6cOXPJuZycHG3evFmbN2/Wyy+/rDlz5mjy5Mn1Gg8AAAAAAMCKGjTgKa9jx46KjY3VihUrHL7PqVOn7OHO4MGDNWbMGPXv31+hoaHKzMzUJ598ov/+9786deqUbr/9drVo0UKjR4+ud63jxo3TU089VeV5Hx+feo8BAAAAAADgLA0a8MycOVNxcXGKi4tTmzZtlJKSoqioKIfv7+HhoUmTJunxxx9Xt27dLjk/cuRIjR49WhMmTFBpaakeeOABHThwQDabrV51BwcHq0ePHvXqAwAAAABQN0ZZiYpOHdTZnD0qzNmtszl7VJJ/TEbpWRllRbJ5+Mjm6SuvgLbyDekhv5Ce8g3pIZ8WXWTzcNk8BsCtNOh3/qxZs+p1/0GDBmnQoEHVthk3bpwmTpyojz/+WIcOHdL27dt1xRVX1GtcAAAAAIBrGYahwswE5R54V3lpK2WUFtR4n5L8dBVm/aCT52/bPP0V2H6EgqPvlF9Yv3r/8R+wkkZxFa1hw4bZjw8dOmRiJQAAAACA2igrzlPugUU6sny00r6ZpDM/fe5QuFMZo7RAZ376XGkrb9GR5dfr5IH/qaw4z8kVA+6pUQQ8Z8+etR97enqaWAkAAAAAwFGnjyxXytJ4ZW59TEW5SU7tuyh3v45vfVQpS+N1+shyp/YNuKNGEfCsXbvWfty1a9d697du3Tr16dNHzZs3V0BAgKKiojR58mQtWbJEhmHUu38AAAAAaMpKCrOVsf5+HVv/G5UWZjfoWKWF2Tq2/jfKWP+ASgtzGnQswEyW331q586d+uKLLyRJPXv2dErAc/jw4Qq3U1JSlJKSog8++ECDBw/W4sWL1a5du1r3m5aWVu35jIyMWvcJAAAAAFZyJnWFjm/5m0rPNmywc8m4R5ap4OdNaj3gGTXrMNKlYwOuYOmA5+zZs7rnnntUWloqSXr66afr1Z+Pj49uvPFGjRw5Uj169FBQUJByc3O1adMmvfHGG0pNTdWGDRs0YsQIbdq0SUFBQbXqv0OHDvWqDwAAAACsLDfpbWVu+7tp45eezVbGd/epVb/HFRwz3bQ6gIZg6YDn/vvvV0JCgiRp2rRpGjt2bL3627Jli4KDgy/5/NChQ3X//ffr5ptv1ooVK5SYmKhZs2bppZdeqtd4AAAAANBU5Ox9Xdk7XzC7DElS5rZZKivJV0j335hdCuA0lg14nn32Wc2dO1eSFBcXp3//+9/17rOycOeC5s2b64MPPtBll12mnJwczZkzR7Nnz5aPj4/D/aemplZ7PiMjQwMGDHC4PwAAAACwgtykt90m3Lkge+cL8vAKYCYPGg1LBjxvvvmm/va3v0mSYmNj9eWXXyowMLDBxw0KCtKtt96q119/XXl5eUpISNCgQYMcvn/79u0bsDoAAAAAcD9nUleYuiyrOpnbZskrIII9edAoWO4qWu+9955+85tz0+g6deqklStXKiwszGXjd+vWzX589OhRl40LAAAAAFZTUpit41v+ZnYZ1Tq+9W9cXQuNgqUCns8//1xTp05VWVmZwsPDtWrVKpfPirHZbC4dDwAAAACsKjPhcZdfLau2SguzdTzhcbPLAOrNMgHPqlWrNGnSJJWUlCg0NFQrV65U586dXV7Hvn377McREREuHx8AAAAArOD0kS915sgXZpfhkDNHlun0keVmlwHUiyUCno0bN2rcuHE6e/asgoKC9PXXX6t79+4ur+PkyZN6//33JUkBAQHq37+/y2sAAAAAAHdXVpynzISZZpdRK5kJ/09lxXlmlwHUmdsHPDt27NANN9ygvLw8BQYG6osvvlC/fv1q3c/QoUNls9lks9mUkpJyyfmvvvpKBQUFVd7/zJkzmjRpkrKzz00vnDFjhnx9fWtdBwAAAAA0dqdTPlNpoXsvzbpYaWG2Tv/0mdllAHXWoFfRWr9+vQ4ePGi/nZWVZT8+ePCg5s+fX6H99OnTK9w+dOiQRo0apdzcXEnSU089paCgIO3Zs6fKMVu3bq3WrVvXutbZs2fr9ttv18SJEzVkyBB17txZzZo108mTJ7Vx40b95z//0ZEjRyRJMTExeuKJJ2o9BgAAAAA0doZhKPfAQrPLqJPc5IVq0XkKe6/Ckho04Jk7d64WLFhQ6bkNGzZow4YNFT53ccDz3Xff6fjx4/bbf/zjH2sc8/HHH69z+JKTk6O5c+dq7ty5VbaJj4/XokWLFBISUqcxAAAAAKAxK8xMUFHufrPLqJOi3P0qzNom/1ZsxwHradCAx0pefPFFrVq1Sps2bVJSUpKysrKUm5urgIAARURE6Morr9SUKVM0cuRI0lwAAAAAqELugXfNLqFecpMXEvDAkmyGYRhmF4Fz0tLS1KFDB0lSamqqyy8BDwAAAAD1YZSV6NCHvWSUVr2/qbuzefqr8y27ZPNgPkRj1hjff7v9JssAAAAAAGsoOnXQ0uGOJBmlBSo6dcjsMoBaI+ABAAAAADjF2ZyqL4hjJY3lcaBpIeABAAAAADhFYc5us0twisbyONC0EPAAAAAAAJyiscx8aSyPA00LAQ8AAAAAwClK8o+ZXYJTlORnmF0CUGsEPAAAAAAApzBKz5pdglMYZY3jcaBpIeABAAAAADiFUVZkdglOYZQ2jseBpoWABwAAAADgFDYPH7NLcAqbZ+N4HGhavMwuAACAhmIYhnLz85WSna2U7BylZGcrJy9PxSWlKi4tVUlZmbw8POTt6SlvL0+FBAYqMjRUkaEhigwLU8uAALMfAgAAlmLz9DW7BKeweTSOx4GmhYAHANCopOee1JbDh3U4K1uHs7N0qqDQ4fum5pzQztQ0++0gf39FhoYqKixUA6KiFBEc1BAlAwDQaHgFtFVJfrrZZdSbV0C42SUAtUbAAwCwvJKyMm0/ckTfJiYp8Zjzrt5xsqBAO9PStDMtTUt27FTX8LYaHhurvh07yMuDVc4AAFzMN6SHCrN+MLuMevMN6WF2CUCtEfAAACzrRF6e1iQf0NqkZOUWFDT4eIkZx5SYcUzBAf4aGh2t+JholnEBAFCOX0hPnTS7CCfwC+lpdglArRHwAAAsp6CoSB8kbNPa5AMqMwyXj5+bX6AlO3bq8527FB99uSbF9Ze/t7fL6wAAwN00lpkvjeVxoGkh4AEAWMre9HS9tX6jsvPyzC5FZYah1UnJ2pV2VHcPGaTuERFmlwQAgKl8WnSRzdNfRmnDz6xtKDZPf/m06Gx2GUCtsYEAAMASCoqKNH/DJr3w9Uq3CHfKy87L0wtfr9T8jZtUUFxsdjkAAJjG5uGlwPYjzC6jXgLbj5DNg7kQsB6+awEAbs+dZu1UZ01SsnYzmwcA0MQFX36Hzvz0udll1Flw9J1mlwDUCTN4AABubfmevW45a6cqF2bzLN+z1+xSAAAwhV+r/vIJjjW7jDrxCe4qv7B+ZpcB1AkBDwDALRmGoY+3/aDFWxPMLqVOFm9N0Mc/bJdhwibQAACYyWazKfhya86CCY6+QzabzewygDoh4AEAuB3DMPS/LVu1dNdus0upl6U7d+l/W7YS8gAAmpzmkePk6Rdqdhm14ukXquadxpldBlBnBDwAALfzyQ/btXJfotllOMXKfYn6ZPsOs8sAAMClPLwD1ar/k2aXUSut456Sh3eg2WUAdUbAAwBwK8v37LX8zJ2LLd25iz15AABNTvOOo9Ws4w1ml+GQZh3HqFmH68wuA6gXAh4AgNvYm55u2T13arJ4a4L2pWeYXQYAAC7Vqv8sefq691ItT79Qte4/y+wygHoj4AEAuIWCoiK9tX6j2WU0qHkbNqiguNjsMgAAcBkvv1C1HvCM2WVUq3XcM/L0CzG7DKDeCHgAAG5hccI2y1wKva6yz+Tpg0Y6QwkAgKo06zBSrfrNNLuMSrXq97iadRhpdhmAUxDwAABMtzc9XWuSks0uwyVWJyWzVAsA0OQEx9yl0N4Pml1GBaG9H1JwzHSzywCchoAHAGCqprA062Is1QIANEUh3X+jVv0eN7sMSVKrfk8opPuvzS4DcCoCHgCAqT5oAkuzLpZ9Jk8fJmwzuwwAAFwuOGa6wq9+07SNlz39QhV+9ZsKjplmyvhAQyLgAQCY5kR+vtYmHzC7DFOsTUrWifx8s8sAAMDlmnUYqU43rFCzjmNcO26nsep0/Qr23EGjRcADADDN2qRklRmG2WWYotQwtK6JhlsAAHj6hSh8yGtqO+R1efo17Gyec7N23lD44Fe5WhYaNS+zCwAANE0lZWVak9w0NlauyuqkJN3Qq6e8PPh7CwCgaWrecbQCw6/R6ZTPlHtgoYpy9zutb5/gWAVH36nmncbJwzvQaf0C7oqABwBgiu1HUpWbX2B2GabKzS/QjiOp6h/ZyexSAAAwjYd3oIIuv00tukxRYdY25SYvVF7aShmltf89webpr2btRyoo+k75hV0hm83WABUD7omABwBgim/3O+8vdFb27f4kAh4AACTZbDb5t+ov/1b9ZZSVqOjUIZ3N2aPCnN06m7NHJfkZMsrOyigtks3TRzYPX3kFhMs3pIf8QnrKN6SHfFp0ls2Dt7lomvjOBwC4XHpurhIzjpldhlvYl5Gh9NyTiggOMrsUAADchs3DS77BMfINjlGLy24yuxzAElj0DwBwuS2HU0wdv6igQLlHjyrzxx+Ve/SoigrMXSq25fBhU8cHAACA9TGDBwDgcoezsl0+pmEYOrZ/v5K+XaUj23+QUVZmP2fz8FDHK65QzLBr1TY21uXr9Q9nu/75AAAAQONCwAMAcCnDMJTi4kAj+6cUrZ/7X+UePVp5TWVl+ikhQT8lJCi4XTsNueeXCu0U6bL6fjIh8AIAAEDjwhItAIBL5ebn66QLl0Sl792jr2Y/WyHcaSPpTkn3n/+3Tfn6jh7VV7OfVfrePS6rMbegQCfy8102HgAAABofAh4AgEu5cvZO9k8pWv2v11Ry9qwkqa+kxZKOSHpH0mvn/z0i6f3z5yWp5OxZrf7Xa8r+KcVltaYwiwcAAAD1QMADAHCplOwcl4xjGIbWz/2vPdwZL2mjpEmSfC5q6yNp8vnz485/ruTsWa2fO1eGYbikXlcvWwMAAEDjQsADAHApVwUZx/bvty/L6ivpPUl+NdzHTxVn8uQeTdPPSfsbrMbyCHgAAABQHwQ8AACXysnLc8k4SatX2Y8fVs3hzgV+kh4qd3v/t986saqquep5AQAAQONEwAMAcKniktIGH6OooEBHfvhB0rkNlCfU8v4TJbU+f3zkh20qcsGm0MWlDf+8AAAAoPEi4AEAuJQrgoz8nBwZZWWSpJG6dM+dmvhIGnX+2CgrU/6JE06srnIEPAAAAKgPAh4AgEuVnA9eGlLx+Y2VJSmojn20KN9fYWG96nFESWnDPy8AAABovAh4AAAu5eXR8P/1ePv62o9P1rGPU+X783N0B5+68/Lkv2QAAADUHb9NAgBcytvTs8HHCAgJke18kLRCUlEt718k6evzxzZPTwW0bOnE6irniucFAAAAjRcBDwDApby9Gj7I8PH3V8crrpAk/Szp01re/xNJx88fd+x7hXz8/Z1YXeUIeAAAAFAfBDwAAJcKCQx0yTgxw661Hz8nydFddAokPV/uduzw4U6sqmquel4AAADQOBHwAABcKjI01CXjtI2NVXC7dpKk7ZJuVc0hT6GkKefbS1Jwu/ZqExPbYDWW56rnBQAAAI0TAQ8AwKUiQ0NcMo7NZtOQe34pr/MbLn8maZCkxbp0T54iSe+fP//Z+c95+fpqyD33yGazuaReAh4AAADUBwEPAMClXBlkhHaK1LD7H7CHPBdm8nSUNFXS/ef/7aCKM3e8fH017P4HFNop0mW1RoYR8AAAAKDuvMwuAADQtAQHBCjI318nCwpcMl5E9x667pG/av3c/yr36FFJ5zZeXlhVfe3aa8g997g03An291fLgACXjQcAAIDGh4AHAOBSNptNkaGh2pmW5rIxQztF6sa/P6Wfk/Zr/7erdOSHH2SUlf1fTZ6e6tj3CsUOH642MbEuW5Z1QSdm7wAAAKCeCHgAAC4XFebagEc6Fyy1je2qtrFdVVRQoPwTJ1RcWChvPz8FtGzpkkuhVyWK/XcAAABQTwQ8AACXGxAVpSU7dpo2vo+/v6mBzsWuvCzK7BIAAABgcQQ8AACXiwgOUtfwtkrMOGZ2KabrFh6u8KAgs8twCaOsREWnDupszh4V5uzW2Zw9Ksk/JqP0rIyyItk8fGTz9JVXQFv5hvSQX0hP+Yb0kE+LLrJ58CsLAABAdfhtCQBgiuGxsQQ8kobHxphdQoMyDEOFmQnKPfCu8tJWyiiteXPtkvx0FWb9oJPnb9s8/RXYfoSCo++UX1g/l++RBAAAYAUEPAAAU/Tt2EHBAf7KzXfN1bTcUXCAv/p27GB2GQ2irDhPp1KW6OSBhSrKTapXX0Zpgc789LnO/PS5fIJjFXz5nWoeOU4e3oFOqhYAAMD6PMwuAADQNHl5eGhodLTZZZhqWEyMPD0a33/Fp48sV8rSeGVufaze4c7FinL36/jWR5WyNF6njyx3at8AAABW1vh+qwQAWEZ8TLQ8muhyG0+bTddEX252GU5VUpitjPX369j636i0MLtBxyotzNax9b9RxvoHVFqY06BjAQAAWAEBDwDANC0DAhTfyEIOR8XHRKtlQIDZZTjNmdQVOvLFKJ058oVrxz2yTD99MVJnUle4dFwAAAB3Q8ADADDVpP79FBrYtPZSCW0WqFv69zO7DKfJTXpbGd/dp9KzDTtrpyqlZ7OV8d19yk2ab8r4AAAA7oCABwBgKn8fH909ZJDZZbjUjMGD5e/tbXYZTpGz93Vlbvu72WVIkjK3zVLO3tfNLgMAAMAUBDwAANN1j4jQ0JimseHysJhodYsIN7sMp8hNelvZO18wu4wKsne+wEweAADQJBHwAADcwuQmsFQrtFmgJsX1N7sMpziTusJtZu5cLHPbLPbkAQAATQ4BDwDALTSFpVqNZWlWSWG2jm/5m9llVOv41r9xdS0AANCkEPAAANxG94gITW4kM1wudmtc/0azNCsz4XHTNlR2VGlhto4nPG52GQAAAC5DwAMAcCuje3TX2F49zS7Dqcb27qXrenQ3uwynOH3kS5dfCr2uzhxZptNHlptdBgAAgEsQ8AAA3M7EK/pqRLeuZpfhFCO6ddXEvn3MLsMpyorzlJkw0+wyaiUz4f+prDjP7DIAAAAaHAEPAMDt2Gw23TYgTmN79zK7lHq5sXcv3TYgTjabzexSnOJ0ymcqLXTvpVkXKy3M1umfPjO7DAAAgAbXoAHP8ePHtWzZMs2cOVOjR49WWFiYbDabbDabpk+fXuv+li9frgkTJqh9+/by9fVV+/btNWHCBC1f7tzp1/n5+Xr++ecVFxenkJAQBQYGKjY2Vn/+85/1008/OXUsAEDlbDabbrqir2X35Jkc118Tr+jbaMIdwzCUe2Ch0/s9k1+mg2lF2nnorA6mFelMfpnTx8hNXijDMJzeLwAAgDvxasjO27Rp45R+ysrKdO+992revHkVPn/06FEdPXpUS5Ys0T333KM333xTHh71y6wOHjyo66+/XgcOHKjw+aSkJCUlJWnu3LlatGiRxowZU69xAACOGd2juzqFhGje+g3KznP/pTahzQI1Y/DgRrOh8gWFmQkqyt3vlL4Mw9D3+wq1aOVpfbMtX6XlMh1PD2lE/wDd9ovmurKbn1MCsqLc/SrM2ib/VtYMCwEAABzhsiVaHTt21MiRI+t030cffdQe7vTt21fvvfeetmzZovfee099+/aVJM2dO1ePPfZYvWo8ffq0brjhBnu488tf/lKrVq3Sxo0b9fTTT6tZs2Y6deqUJk+erB07dtRrLACA47pFhOupCeM0NCba7FKqNSwmWk+NH9fowh1Jyj3wrlP62Xv4rMY8kq6pz/ysr7dWDHckqbRM+mpLvqY+87PGPJKuvYfPOmXc3GTnzz4CAABwJzajAecsP/7444qLi1NcXJzatGmjlJQURUVFSZKmTZum+fPn19hHcnKyunfvrpKSEvXv31/r1q2Tv7+//Xx+fr7i4+OVkJAgLy8vJSYmqkuXLnWqd+bMmXryySclSc8//7wefPDBCuc3btyo+Ph4lZSUKD4+XmvWrKnTOFVJS0tThw4dJEmpqalq3769U/sHgMZgb3q63lq/0a1m8zTWWTsXGGUlOvRhLxmlBfXqZ8PuAv325ePKP/t/v3q0kTRSUpCkk5JWSPq53H0CfG369x9ba3BPf9WHzdNfnW/ZJZtHg05eBgAAFtEY33836AyeWbNmacyYMfVaqvXKK6+opKREkvTaa69VCHckKSAgQK+99pokqaSkRC+//HKdxikuLtarr74qSeratav+/Oc/X9Jm0KBBmjFjhiRp7dq12rp1a53GAgDUXfeICD01YZyGx8bIw+T9bTxtNg2PjWm0s3YuKDp1sN7hzt7DZyuEO30lLZZ0RNI7kl47/+8RSe+fPy9J+WcN/fbl4/WeyWOUFqjo1KF69QEAAODO3PoqWoZh6LPPzl35IjY2VgMHDqy03cCBAxUTEyNJ+uyzz+q0keLq1at18uRJSedmF1W1l0/5zaE//fTTWo8DAKg/f29vTb1qoP4x6WaN79NbwQH1m91RW8EB/prQt49enHSzpl41UP7e3i4d39XO5uyp1/0Nw9BD/8myhzvjJW2UNEmSz0VtfSRNPn9+3PnP5Z819PB/suq9UXJ9HwcAAIA7c+t5yocPH1Z6erokKT4+vtq28fHxSkpK0tGjRyssBXPU+vXrK/RVlf79+ysgIED5+fnasGFDrcYAADhXy4AAje/bR2N699L2I6n6dv9+JWYca7DxuoWHa3hsjPp07CCvem7qbyWFObvrdf/v9xXqQFqxpHMzc96T5FfDffx0bibPIEnbJSWnFWtLYqGu7Fb3MK8wZ7daXHZTne8PAADgztw64Nm3b5/9ODY2ttq25c8nJibWOuBxdCwvLy916dJFu3btUmJiYq3GAAA0DC8PD8VFdlJcZCel557UlsOHdTg7WylZ2TpZUPelRcH+/uoUFqqo0FANiIpSRHCQE6u2jvrOfPnfN6ftxw+r5nDnAj9JD0maUq6f+gQ8zOABAACNmVsHPGlpafbjmjY8urA5knRug6S6jhUYGKjg4OAax9q1a5cyMzN19uxZ+fr61mqMqmRkZDjUDwCgahHBQRrft4/99on8fKVkZSsl+9xHTl6eiktLVVxaqpLSMnl5esjb01Penp4KCQxUZGjouY+wULUMCDDvgbiRkvy6z4o6k1+mlQn5ks5tqDyhlvefKKm1pOOSVmzN15n8MjULqNvsqZJ8/p8FAACNl1sHPKdP/99f/Jo1a1Zt28DAQPvxmTNn6jxWTeNUNpajAU/5EAoA4BotAwLUsmOA+nbkNbiujNK6b3B8LKfEfin0kbp0z52a+EgaJWmhzl1C/diJEnUJqG0v5xhlzrnkOgAAgDty6w0ECgsL7cc+PtX/Mlc+ZCmow3T8C2PVNI4zxgIAwEqMsqI63zev3CXR67rArUX5/grrvtGyUVr3xwEAAODu3HoGj5/f/63SLyqq/peys2f/769yF19KvTZj1TROfcaqaelYRkaGBgwY4HB/AAC4gs2jbjNmJCnQ9/8uZX+yjn2cKt+fn63KdjWxedb9cQAAALg7tw54mjdvbj+uadlVXl6e/diRZVZVjeXI8q66jlXTPkIAALgjm6djS5Er0zbES54e55ZXrZBUpNot0yqS9PX5Yy9PqW3Luv/qYvOo++MAAABwd269RKt8IFLTBsXlZ8fUZa+bC2Pl5eUpNzfXobFatWrl8P47AABYlVdA2zrft1mAh0b0P7dZ9c+SPq3l/T/RuQ2WJWlE/4A6b7AsSV4B4XW+LwAAgLtz64CnW7du9uP9+/dX27b8+a5duzbYWCUlJTp06FCdxwEAwGp8Q3rU6/63/eL/ZuQ+J6mw6qYVFEh6vop+6qK+jwMAAMCduXXAExUVpYiICEnS2rVrq227bt06SVK7du0UGRlZ67GGDBliP65urISEBPsSrcGDB9d6HAAArMYvpGe97n9lNz9d3t5bkrRd0q2qOeQplDTlfHtJim7vrQFd/aq5R83q+zgAAADcmVsHPDabTePGjZN0blbN5s2bK223efNm+6ybcePGyWar/QaMQ4cOVVDQuet7LFiwQIZR+VU65s+fbz+eMGFCrccBAMBq6jvzxWaz6flfhSng/IbLn0kaJGmxzu2xU16RpPfPn//s/OcCfG167ldhdfr/vTxm8AAAgMbMrQMeSfrDH/4gT09PSdIDDzxwyWXJCwoK9MADD0iSvLy89Ic//KHSfqZPny6bzSabzaY1a9Zcct7Hx0e/+93vJEmJiYl68cUXL2mzadMmzZs3T5IUHx+vuLi4uj4sAAAsw6dFF9k8a3+FyvK6R/nq339sbQ95Lszk6ShpqqT7z//bQRVn7gT42vTvP7ZW96j67Xln8/SXT4vO9eoDAADAnTXoVbTWr1+vgwcP2m9nZWXZjw8ePFhhNox0LoS5WHR0tB588EHNnj1bCQkJGjx4sB5++GF17txZhw4d0nPPPaft28/9Gvjggw/q8ssvr3O9Dz74oBYvXqzk5GQ99NBDOnjwoG699Vb5+/tr9erVeuaZZ1RSUiJ/f3+98sordR4HAAArsXl4KbD9CJ356fN69TO4p78W/b+2eug/WTqQVizp3MbLC6toH93eW8/9Kqze4Y4kBbYfIZuHW188FAAAoF5sRlVrkZxg+vTpWrBggcPtqyqlrKxMv/zlL/XWW29Ved8ZM2Zozpw58vCofFJS+VpWr16toUOHVtru4MGDuv7663XgwIFKz7do0UKLFi3SmDFjqnkkdZOWlma/AlhqaiqXVQcAuI2C41uV9s0kp/RlGIa2JBZq0crTWpmQr9Ky/zvn5Xnualm3/aK5BnT1q/eyrAvaj/hQ/q36O6UvAABgfY3x/bcl/pTl4eGhefPm6aabbtKcOXO0detWZWVlKSwsTHFxcbrvvvs0evRop4zVpUsXbd++Xf/+97/14Ycf6uDBgyoqKlKHDh10/fXX6/e//706derklLEAALAKv1b95RMcq6Lc6q9q6QibzaYru/nrym7+OpNfpmMnSpRXaCjQz6a2Lb3qdSn0yvgEd5VfWD+n9gkAAOBuGnQGD2qnMSaIAIDG4+SB/+n41kfNLqPWWg94WkFdbjO7DAAA4EYa4/tvt99kGQAAuIfmkePk6Rdqdhm14ukXquadxpldBgAAQIMj4AEAAA7x8A5Uq/5Pml1GrbSOe0oe3oFmlwEAANDgCHgAAIDDmnccrWYdbzC7DIc06zhGzTpcZ3YZAAAALkHAAwAAaqVV/1ny9HXvpVqefqFq3X+W2WUAAAC4DAEPAACoFS+/ULUe8IzZZVSrddwz8vQLMbsMAAAAlyHgAQAAtdasw0i16jfT7DIq1arf42rWYaTZZQAAALgUAQ8AAKiT4Ji7FNr7QbPLqCC090MKjpludhkAAAAuR8ADAADqLKT7b9Sq3+NmlyFJatXvCYV0/7XZZQAAAJiCgAcAANRLcMx0hV/9pmkbL3v6hSr86jcVHDPNlPEBAADcAQEPAACot2YdRqrTDSvUrOMY147baaw6Xb+CPXcAAECTR8ADAACcwtMvROFDXlPbIa/L069hZ/Ocm7XzhsIHv8rVsgAAACR5mV0AAABoXJp3HK3A8Gt0OuUz5R5YqKLc/U7r2yc4VsHRd6p5p3Hy8A50Wr8AAABWR8ADAACczsM7UEGX36YWXaaoMGubcpMXKi9tpYzSglr3ZfP0V7P2IxUUfaf8wq6QzWZrgIoBAACsjYAHAAA0GJvNJv9W/eXfqr+MshIVnTqkszl7VJizW2dz9qgkP0NG2VkZpUWyefrI5uErr4Bw+Yb0kF9IT/mG9JBPi86yefArCwAAQHX4bQkAALiEzcNLvsEx8g2OUYvLbjK7HAAAgEaFTZYBAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAszsvsAgAAAICmyDAM5ebnKyU7WynZOUrJzlZOXp6KS0pVXFqqkrIyeXl4yNvTU95engoJDFRkaKgiQ0MUGRamlgEBZj8EAIAbIeABAAAAXCQ996S2HD6sw1nZOpydpVMFhQ7fNzXnhHamptlvB/n7KzI0VFFhoRoQFaWI4KCGKBkAYBEEPAAAAEADKikr0/YjR/RtYpISjx1zWr8nCwq0My1NO9PStGTHTnUNb6vhsbHq27GDvDzYiQEAmhoCHgAAAKABnMjL05rkA1qblKzcgoIGHy8x45gSM44pOMBfQ6OjFR8TzTIuAGhCCHgAAAAAJyooKtIHCdu0NvmAygzD5ePn5hdoyY6d+nznLsVHX65Jcf3l7+3t8joAAK5FwAMAAAA4yd70dL21fqOy8/LMLkVlhqHVScnalXZUdw8ZpO4REWaXBABoQAQ8AAAAQD0VFBVp8dZtWpOcbHYpl8jOy9MLX6/U0JhoTWY2DwA0Wm6/+9rQoUNls9lq9bFmzZpaj/PEE080aP8AAABonPamp+uxJZ+7ZbhT3pqkZD326Wfam55udikAgAbg9gFPbXl4eOjyyy83uwwAAAA0Acv37NULX690iyVZjrgwm2f5nr1mlwIAcDK3X6L19ttvK6+G/zD37dunyZMnS5KuvfZatWvXrl5j7t69u9rzUVFR9eofAAAA1mYYhj75YbuW7qr+90Z3tXhrgvKLijSxbx/ZbDazywEAOIHbBzyOhCkLFy60H0+dOrXeY/bo0aPefQAAAKBxMgxD/9uyVSv3JZpdSr0s3blLhcXFum1AHCEPADQCll+iVVZWpkWLFkmSmjVrpokTJ5pcEQAAABqzT37Ybvlw54KV+xL1yfYdZpcBAHACywc8q1at0tGjRyVJN998swICAkyuCAAAAI3V8j17LbssqypLd+5iTx4AaAQsH/C888479mNnLM8CAAAAKrM3PV2LtyaYXUaDWLw1QfvSM8wuAwBQD26/B091zpw5o08//VSS1KlTJw0dOtQp/Y4cOVI7duxQbm6ugoOD1a1bN1133XW677771LJlyzr3m5aWVu35jAz+UwUAAHBHBUVFemv9RrPLaFDzNmzQU+PHyd/b2+xSAAB1YOmA5+OPP7ZfYeuOO+5w2uZwK1eutB9nZmZq7dq1Wrt2rZ577jnNnz9f48aNq1O/HTp0cEp9AAAAcK3FCdsscyn0uso+k6cPtiZo2qCrzC4FAFAHll6i5ezlWT179tT/+3//T0uXLtW2bdu0efNmLViwQCNHjpQk5ebm6qabbtLy5cvrPRYAAACsYW96utYkJZtdhkusTkpmqRYAWJTNMAzD7CLqIi0tTZ06dVJZWZkGDhyoTZs21au/C8uxqvLmm2/qV7/6lSQpIiJChw4dkp+fX63GcGSJ1oABAyRJqampat++fa36BwAAgHMVFBXpsSWfN/rZO+WFNgtkqRaARi8tLc2+yqaxvP+27BKtd999V2VlZZKkadOm1bu/6sIdSbrvvvu0detWzZs3T+np6fr44491++2312qMxvANAwAA0JR80ASWZl0s+0yePkzYpqlXDTS7FABALVh2idbChQslSb6+vpo8ebJLxrzvvvvsx2vXrnXJmAAAADDHifx8rU0+YHYZpliblKwT+flmlwEAqAVLBjwJCQnat2+fJGnMmDH1urJVbXTr1s1+fPToUZeMCQAAAHOsTUpWmTV3M6i3UsPQuiYabgGAVVky4Cm/ubIzlmc5yllX6QIAAIB7Kykr05rkprGxclVWJyWp5PyWCAAA92e5gKe4uFjvv/++JKlVq1YaPXq0y8a+MGtIOrfRMgAAABqn7UdSlZtfYHYZpsrNL9COI6lmlwEAcJDlAp7ly5crMzNTknTbbbfJy8t1+0S/+eab9uP4+HiXjQsAAADX+nb/frNLcAvf7k8yuwQAgIMsF/CUX541depUh+4zf/582Ww22Ww2PfHEE5ec3717tw4ePFhtH3PmzNHcuXMlSW3bttWECRMcLxoAAACWkZ6bq8SMY2aX4Rb2ZWQoPfek2WUAABxgqcuknzhxQsuWLZMk9ejRQ1dccYVT+t22bZvuueceDRs2TKNHj1bPnj0VGhqqkpIS7d+/X4sWLdKKFSskSZ6enpozZ44CAwOdMjYAAADcy5bDKWaX4Fa2HD6s8X37mF0GAKAGlgp4Fi9erLNnz0pyfPaOo0pLS/XNN9/om2++qbJNaGio5s2bp7Fjxzp1bAAAALiPw1nZZpfgVg5n83wAgBVYKuBZuHChpHOzaG6//Xan9Xv99ddr3rx52rRpk7Zv366ff/5Z2dnZMgxDISEh6t27t6677jpNnz5dLVq0cNq4AAAAcC+GYSiFQKOCnwi8AMASbIZhGGYXgXPS0tLUoUMHSVJqaqrat29vckUAAABNy4m8PP3xg4/MLsPtvDz5FrUMCDC7DABwmsb4/ttymywDAAAADYXZO5VLYRYPALg9Ah4AAADgvJTsHLNLcEsEXwDg/gh4AAAAgPMIMirH8wIA7o+ABwAAADgvJy/P7BLcEs8LALg/Ah4AAADgvOKSUrNLcEvFpTwvAODuCHgAAACA8wgyKsfzAgDuj4AHAAAAOK+krMzsEtxSSSnPCwC4OwIeAAAA4DwvD349royXJ88LALg7XqkBAACA87w9Pc0uwS3xvACA+yPgAQAAAM7z9iLIqAwBDwC4PwIeAAAA4LyQwECzS3BLPC8A4P4IeAAAAIDzIkNDzS7BLfG8AID7I+ABAAAAzosMDTG7BLdEwAMA7o+ABwAAADiPIKNykWE8LwDg7gh4AAAAgPOCAwIU5O9vdhluJdjfXy0DAswuAwBQAwIeAAAA4DybzcYsnot0YvYOAFgCAQ8AAABQThSBRgVRBF4AYAkEPAAAAEA5A6KizC7BrVx5Gc8HAFgBAQ8AAABQTkRwkLqGtzW7DLfQLTxc4UFBZpcBAHAAAQ8AAABwkeGxsWaX4BaGx8aYXQIAwEEEPAAAAMBF+nbsoOCApn01reAAf/Xt2MHsMgAADiLgAQAAAC7i5eGhodHRZpdhqmExMfL04O0CAFgFr9gAAABAJeJjouVhs5ldhik8bTZdE3252WUAAGqBgAcAAACoRMuAAMU30ZAjPiZaLQMCzC4DAFALBDwAAABAFSb176fQwECzy3Cp0GaBuqV/P7PLAADUEgEPAAAAUAV/Hx/dPWSQ2WW41IzBg+Xv7W12GQCAWiLgAQAAAKrRPSJCQ2OaxobLw2Ki1S0i3OwyAAB1QMADAAAA1GByE1iqFdosUJPi+ptdBgCgjgh4AAAAgBo0haVaLM0CAGsj4AEAAAAc0D0iQpMb6QyXW+P6szQLACyOgAcAAABw0Oge3TW2V0+zy3Cqsb176boe3c0uAwBQTwQ8AAAAQC1MvKKvRnTranYZTjGiW1dN7NvH7DIAAE7gZXYBAAAAgJXYbDbdNiBOft7eWrpzl9nl1NmNvXtpQt8+stlsZpcCAHACAh4AAACglmw2m266oq8CfHy0eGuC2eXU2uS4/hrNsiwAaFQIeAAAAIA6Gt2juzqFhGje+g3Kzsszu5wahTYL1IzBg9lQGQAaIfbgAQAAAOqhW0S4npowTkNjos0upVrDYqL11PhxhDsA0EgxgwcAAACoJ39vb00fdJXiIjvprfUb3Wo2D7N2AKBpYAYPAAAA4CTdIyL01IRxGh4bIw+TNy/2tNk0PDaGWTsA0EQwgwcAAABwIn9vb029aqDG9u6ltUnJWpOcrNz8ApeNHxzgr2ExMbom+nK1DAhw2bgAAHMR8AAAAAANoGVAgMb37aMxvXtp+5FUfbt/vxIzjjXYeN3CwzU8NkZ9OnaQlwcT9QGgqSHgAQAAABqQl4eH4iI7KS6yk9JzT2rL4cM6nJ2tlKxsnSyo+8yeYH9/dQoLVVRoqAZERSkiOMiJVQMArIaABwAAAHCRiOAgje/bx377RH6+UrKylZJ97iMnL0/FpaUqLi1VSWmZvDw95O3pKW9PT4UEBioyNPTcR1goy68AABUQ8AAAAAAmaRkQoJYdA9S3YwezSwEAWByLcwEAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOK8zC4AAAAAAOAcRlmJik4d1NmcPSrM2a2zOXtUkn9MRulZGWVFsnn4yObpK6+AtvIN6SG/kJ7yDekhnxZdZPPg7SFgZfwEAwAAAICFGYahwswE5R54V3lpK2WUFtR4n5L8dBVm/aCT52/bPP0V2H6EgqPvlF9YP9lstoYtGoDTEfAAAAAAgAWVFefpVMoSnTywUEW5SfXqyygt0JmfPteZnz6XT3Csgi+/U80jx8nDO9BJ1QJoaOzBAwAAAAAWc/rIcqUsjVfm1sfqHe5crCh3v45vfVQpS+N1+shyp/YNoOEQ8AAAAPz/9u48uor6/v/46yYhe0JIIEIIiwIhKNRaFkF2lSiyGamiVbZCRRGq369f9Vutgv0Kota2/jithYpQUUFFi6wtSCEKBCHIobiwGiCBoEkgBMh6k/n9QXMbzHqX3LmT+3yck3MGZu7n/Z5MPnfuvO9nPgMAFmEvyVfO9lk6s32mKkrymzRWRUm+zmyfqZzts1VRcrZJYwFwHwUeAAAAALCAi1mbdHL9bbp4cr13455cpxPrU3Qxa5NX4wJwDgUeAAAAAPBxBYeWKuezGaoobdpRO3WpKM1XzmczVHBomSnxATSMAg8AAAAA+LCzX/1JuXt/Y3YakqTcvc/r7Fd/MjsNALWgwAMAAAAAPqrg0FLl73/F7DSukL//FUbyAD6IAg8AAAAA+KCLWZt8ZuTOD+XufZ45eQAfQ4EHAAAAAHyMvSRf3+9+2uw06vX9nqd5uhbgQyjwAAAAAICPyc2YY9qEyo1VUZKv7zPmmJ0GgH+jwAMAAAAAPuTCyQ1efxS6qy6eXKcLJzeanQYAUeABAAAAAJ9RWX5JuRnPmZ2GU3IznlVl+SWz0wD8HgUeAAAAAPARF45/rIoS374164cqSvJ14cTHZqcB+D1LFHhsNlujfoYNG+aReCtWrFBKSoratm2r0NBQderUSQ888IDS09M90j4AAAAA/JBhGCo4stzsNFxScHi5DMMwOw3Ar1miwOMtxcXFGjVqlH72s59p8+bN+u6771RaWqqTJ0/qnXfe0aBBg/T888+bnSYAAACAZqgkN0NlBQfNTsMlZQUHVZK31+w0AL8WZHYCznj44Yc1c+bMOtdHRES41f7Pf/5zbdiwQZI0fPhwPfroo0pISNCBAwc0f/58HTt2THPnzlW7du304IMPuhULAAAAAKorOPK22Sm4peDwcoW16WN2GoDfslSBJz4+Xj179myStv/5z39q5cqVkqQxY8bob3/7mwIDAyVJffv21dixY9W7d2+dPHlSTz31lO6++261atWqSXIBAAAA4F+MSrsuZW82Ow23XMreLKPSLluApS4zgWaDW7T+7be//a0kKSgoSH/6058cxZ0qrVu31ksvvSRJKigo0BtvvOH1HAEAAAA0T2WFR2VUFJudhluMimKVFR4zOw3Ab1HgkXThwgVt2bJFknTrrbcqMTGx1u3uuusuRUdHS5L+9re/eS0/AAAAAM1b6dkvzU7BI5rLfgBWRIFH0p49e1RWViZJGjp0aJ3bBQcHq3///o7XlJeXeyU/AAAAAM1bydkDZqfgEc1lPwArslSB54MPPtC1116r8PBwRUVFqVu3bpo8ebK2bt3qVrtff/21Yzk5ObnebavW2+12HTlyxK24AAAAACA1n5EvzWU/ACuy1OxX1QsxknT06FEdPXpUb731lu68804tW7ZMLVu2dLrd7Oxsx3Jdt2dV6dChg2M5KytL1157rUtxapOTk9PotgAAAAA0H/aiM2an4BH2Iq5pALNYosATHh6usWPH6pZbblFycrIiIyOVm5urtLQ0/fnPf1Z+fr5Wr16tcePGafPmzWrRooVT7V+4cMGxHBkZWe+21R/FfvHiRafiVC8OAQAAAEAVo6LU7BQ8wqhsHvsBWJElCjynTp1STExMjf8fMWKEZs+erZEjR2rfvn1KS0vT66+/rl/+8pdOtV9SUuJYDg4OrnfbkJAQx3JxsbVnuQcAAADgG4zKMrNT8AijonnsB2BFlijw1FbcqXLVVVdp1apVSk5OVnl5uRYuXOh0gSc0NNSxXDXZcl1KS/9TkQ4LC3MqTlZWVr3rc3Jy1K9fP6faBAAAAGB9toD6v2i2Cltg89gPwIosUeBpyDXXXKMRI0Zow4YNOnr0qE6fPq2EhIRGvz4qKsqx3NBtV5cuXXIsN3Q71w81NL8PAAAAAP9kCwxpeCMLsAU0j/0ArMhST9GqT/XJjk+dOuXUa6sXXhqaCLn6KBzm1AEAAADgCUHhbc1OwSOCwtuZnQLgt5pNgcdms7n82urFoYMHD9a7bdX6oKAgdevWzeWYAAAAAFAlJLan2Sl4RHPZD8CKmk2Bp/oj1J25PUuS+vbt65hcOS0trc7tysrKtGvXLsdrnH1aFwAAAADUJjS2l9kpeERz2Q/AippFgSczM1ObN2+WJHXp0kXt27d36vVRUVG65ZZbJEmffPJJnbdpffTRRyosLJQkpaamupExAAAAAPxHcxn50lz2A7Ainy/wrF27Vna7vc713333ncaPH+94+tXMmTNrbLNs2TLZbDbZbDbNnTu31nb+53/+R5Jkt9v1yCOPqKKi4or1eXl5euqppyRdfqrX9OnTXdkdAAAAAKghOLqrbIHOPaXX19gCwxQc3cXsNAC/5fNP0Zo9e7bKy8s1fvx4DRgwQJ07d1ZYWJjy8vK0bds2LVq0SHl5eZKkQYMG6ZFHHnEpzs0336x7771XK1eu1Jo1azRixAg99thjSkhI0IEDBzRv3jydPHlSkvTSSy+pVatWHttHAAAAAP7NFhCkiMQRunhijdmpuCwicYRsAT5/iQk0W5bofadPn9bChQu1cOHCOrcZP3683njjDYWEuP5YvjfffFOFhYXasGGDtm7dqq1bt16xPiAgQM8++6wefPBBl2MAAAAAQG1iuj1g6QJPTNJEs1MA/JrPF3j++te/Ki0tTenp6fr222+Vl5enwsJCRUZGqkOHDrrppps0efJkDRgwwO1YYWFhWr9+vd59910tW7ZM+/fvV0FBga666ioNHjxYs2bN8kgcAAAAAPih0DZ9FByTrLKC+p/s64uCY3ootHVvs9MA/JrNMAzD7CRwWXZ2tjp06CBJysrKUmJioskZAQAAAPCm80fe1fd7njE7DafF95unll1/ZnYaQKM1x+tvn59kGQAAAAD8RVTncQoMjTM7DacEhsYpqtM4s9MA/B4FHgAAAADwEQEtItSmz/+ZnYZT4vu+oIAWEWanAfg9CjwAAAAA4EOiOo5UZMdRZqfRKJEdRyuyw+1mpwFAFHgAAAAAwOe06fO8AkN8+1atwNA4xfd53uw0APwbBR4AAAAA8DFBoXGK7zff7DTqFd93vgJDY81OA8C/UeABAAAAAB8U2SFFbXo/Z3YatWrTe44iO6SYnQaAaijwAAAAAICPiuk+VXHXP2F2GleIu/5JxXSfYnYaAH6AAg8AAAAA+LDY62aqTe85ZqchSWrTe65ir3vY7DQA1IICDwAAAAD4uJjuU9Ru8CLTJl4ODI1Tu8GLFNN9sinxATSMAg8AAAAAWEBkhxR1GrVJkR1HezdupzHqdMcm5twBfBwFHgAAAACwiMDQWLUbtFBtB/1JgaFNO5rn8qid19Vu4P/jaVmABQSZnQAAAAAAwDlRHUcqot0QXTj+sQqOLFdZwUGPtR0ck6yYpImK6jROAS0iPNYugKZFgQcAAAAALCigRYRadvuZorvep5K8vSo4vFyXsjfLqCh2ui1bYJgiE1PUMmmiQlv/RDabrQkyBtCUKPAAAAAAgIXZbDaFtemjsDZ9ZFTaVVZ4TKVnv1TJ2QMqPful7EU5MipLZVSUyRYYLFtAiILC2ykktqdCY3spJLangqO7yBbA5SFgZfRgAAAAAGgmbAFBConprpCY7oq+ZrzZ6QDwIiZZBgAAAAAAsDgKPAAAAAAAABZHgQcAAAAAAMDiKPAAAAAAAABYHAUeAAAAAAAAi6PAAwAAAAAAYHEUeAAAAAAAACyOAg8AAAAAAIDFUeABAAAAAACwOAo8AAAAAAAAFkeBBwAAAAAAwOIo8AAAAAAAAFgcBR4AAAAAAACLo8ADAAAAAABgcRR4AAAAAAAALI4CDwAAAAAAgMVR4AEAAAAAALA4CjwAAAAAAAAWR4EHAAAAAADA4ijwAAAAAAAAWBwFHgAAAAAAAIujwAMAAAAAAGBxFHgAAAAAAAAsjgIPAAAAAACAxVHgAQAAAAAAsDgKPAAAAAAAABZHgQcAAAAAAMDiKPAAAAAAAABYHAUeAAAAAAAAi6PAAwAAAAAAYHEUeAAAAAAAACyOAg8AAAAAAIDFUeABAAAAAACwOAo8AAAAAAAAFkeBBwAAAAAAwOIo8AAAAAAAAFgcBR4AAAAAAACLo8ADAAAAAABgcRR4AAAAAAAALI4CDwAAAAAAgMVR4AEAAAAAALA4CjwAAAAAAAAWR4EHAAAAAADA4ijwAAAAAAAAWBwFHgAAAAAAAIujwAMAAAAAAGBxFHgAAAAAAAAsjgIPAAAAAACAxVHgAQAAAAAAsDgKPAAAAAAAABZHgQcAAAAAAMDiKPAAAAAAAABYHAUeAAAAAAAAi6PAAwAAAAAAYHEUeAAAAAAAACzOEgWejIwM/eY3v1FKSooSExMVEhKiyMhIJSUlaerUqdq+fbtH4sydO1c2m61RP9u2bfNITAAAAAAAAHcFmZ1AQ4YMGaLPPvusxv+XlZXpyJEjOnLkiJYtW6ZJkybpL3/5i4KDg03IEgAAAAAAwDw+X+A5ffq0JCkhIUF33323Bg8erI4dO6qiokLp6el69dVXderUKb311lsqLy/Xu+++65G4Bw4cqHf91Vdf7ZE4AAAAAAAA7vL5Ak9ycrLmz5+v8ePHKzAw8Ip1/fv318SJEzVw4EAdPnxYK1as0EMPPaQhQ4a4Hbdnz55utwEAAAAAAOANPj8Hz7p163TPPffUKO5Uad26tV599VXHv1etWuWt1AAAAAAAAHyCzxd4GmP48OGO5WPHjpmYCQAAAAAAgPc1iwJPaWmpY7mukT4AAAAAAADNVbMo8KSlpTmWe/To4ZE2U1JSFB8fr+DgYMXHx2vYsGFasGCBzp0755H2AQAAAAAAPMXnJ1luSGVlpRYsWOD49z333OORdjdv3uxYzs3NVVpamtLS0vTSSy9p2bJlGjdunNNtZmdn17s+JyfH6TYBAAAAAAAsX+D5/e9/r927d0uS7rrrLvXu3dut9nr16qU777xT/fr1U0JCgsrLy3Xo0CG988472rRpkwoKCjR+/HitXbtWI0eOdKrtDh06uJUbAAAAAABAbWyGYRhmJ+GqtLQ03XrrrbLb7YqPj9eBAwcUHx/vcnsFBQWKiYmpc/2iRYv00EMPSZISEhJ07NgxhYaGNrp9m83W6G2zsrKUmJjY6O0BAAAAAEDjZGdnOwZhNJfrb8uO4Pnqq6+Umpoqu92u0NBQffDBB24VdyTVW9yRpBkzZmjPnj1asmSJTp8+rQ8//FD3339/o9vPysqqd31OTo769evX6PYAAAAAAAAkixZ4MjMzlZKSonPnzikwMFArV67UkCFDvBJ7xowZWrJkiaTLI4icKfA0h4ogAAAAAADwPZZ7itbp06d166236vTp07LZbHrzzTddmvDYVddee61j+dSpU16LCwAAAAAAUBdLFXjy8vI0YsQIffvtt5KkhQsXatKkSV7NwZl5dAAAAAAAALzBMgWe8+fP67bbbtPXX38tSVqwYIEeeeQRr+dRFV+6PNEyAAAAAACA2SxR4CkqKtKoUaP0xRdfSJKeeeYZPfXUU6bksmjRIsfy0KFDTckBAAAAAACgOp8v8JSVlSk1NVU7duyQJD366KN64YUXnG5n2bJlstlsstlsmjt3bo31Bw4c0NGjR+ttY/HixXrjjTckSW3btlVqaqrTeQAAAAAAAHiazz9F67777tOmTZskSTfffLOmTZumL7/8ss7tg4ODlZSU5HScvXv3avr06Ro+fLhGjhypXr16KS4uTna7XQcPHtQ777zjyCMwMFCLFy9WRESEazsFAAAAAADgQT5f4Pnoo48cy//85z/1ox/9qN7tO3XqpOPHj7sUq6KiQp988ok++eSTOreJi4vTkiVLNGbMGJdiAAAAAAAAeJrPF3i85Y477tCSJUuUnp6uffv26bvvvlN+fr4Mw1BsbKyuv/563X777ZoyZYqio6PNThcAAAAAAMDBZhiGYXYSuCw7O1sdOnSQJGVlZSkxMdHkjAAAAAAAaH6a4/W3z0+yDAAAAAAAgPpR4AEAAAAAALA4CjwAAAAAAAAWR4EHAAAAAADA4ijwAAAAAAAAWBwFHgAAAAAAAIujwAMAAAAAAGBxFHgAAAAAAAAsjgIPAAAAAACAxVHgAQAAAAAAsDgKPAAAAAAAABZHgQcAAAAAAMDiKPAAAAAAAABYHAUeAAAAAAAAi6PAAwAAAAAAYHEUeAAAAAAAACyOAg8AAAAAAIDFUeABAAAAAACwOAo8AAAAAAAAFhdkdgIAAAAAAM8wKu0qKzyq0rNfquTsAZWe/VL2ojMyKkplVJbJFhAsW2CIgsLbKiS2p0JjeykktqeCo7vKFsDlIWBl9GAAAAAAsDDDMFSSm6GCI2/rUvZmGRXFDb7GXnRaJXlf6Py//20LDFNE4gjFJE1UaOvestlsTZs0AI+jwAMAAAAAFlRZfkmFx1fr/JHlKis45FZbRkWxLp5Yo4sn1ig4Jlkx3SYqqvM4BbSI8FC2AJoac/AAAAAAgMVcOLlRx9cOVe6eX7td3PmhsoKD+n7PMzq+dqgunNzo0bYBNB0KPAAAAABgEfaSfOVsn6Uz22eqoiS/SWNVlOTrzPaZytk+WxUlZ5s0FgD3UeABAAAAAAu4mLVJJ9ffposn13s37sl1OrE+RRezNnk1LgDnUOABAAAAAB9XcGipcj6boYrSph21U5eK0nzlfDZDBYeWmRIfQMMo8AAAAACADzv71Z+Uu/c3ZqchScrd+7zOfvUns9MAUAsKPAAAAADgowoOLVX+/lfMTuMK+ftfYSQP4IMo8AAAAACAD7qYtclnRu78UO7e55mTB/AxFHgAAAAAwMfYS/L1/e6nzU6jXt/veZqnawE+hAIPAAAAAPiY3Iw5pk2o3FgVJfn6PmOO2WkA+DcKPAAAAADgQy6c3OD1R6G76uLJdbpwcqPZaQAQBR4AAAAA8BmV5ZeUm/Gc2Wk4JTfjWVWWXzI7DcDvUeABAAAAAB9x4fjHqijx7VuzfqiiJF8XTnxsdhqA36PAAwAAAAA+wDAMFRxZbnYaLik4vFyGYZidBuDXKPAAAAAAgA8oyc1QWcFBs9NwSVnBQZXk7TU7DcCvUeABAAAAAB9QcORts1NwS8Fha44+ApoLCjwAAAAAYDKj0q5L2ZvNTsMtl7I3y6i0m50G4Lco8AAAAACAycoKj8qoKDY7DbcYFcUqKzxmdhqA36LAAwAAAAAmKz37pdkpeERz2Q/AiijwAAAAAIDJSs4eMDsFj2gu+wFYEQUeAAAAADBZcxn50lz2A7AiCjwAAAAAYDJ70RmzU/AIe1GO2SkAfosCDwAAAACYzKgoNTsFjzAqm8d+AFZEgQcAAAAATGZUlpmdgkcYFc1jPwArosADAAAAACazBQSbnYJH2AKbx34AVkSBBwAAAABMZgsMMTsFj7AFNI/9AKyIAg8AAAAAmCwovK3ZKXhEUHg7s1MA/BYFHgAAAAAwWUhsT7NT8Ijmsh+AFVHgAQAAAACThcb2MjsFj2gu+wFYEQUeAAAAADBZcxn50lz2A7AiCjwAAAAAYLLg6K6yBYaZnYZbbIFhCo7uYnYagN+iwAMAAAAAJrMFBCkicYTZabglInGEbAFBZqcB+C0KPAAAAADgA2K6PWB2Cm6JSZpodgqAX6PAAwAAAAA+ILRNHwXHJJudhkuCY3ootHVvs9MA/BoFHgAAAADwATabTTHdrDkKJibpAdlsNrPTAPwaBR4AAAAA8BFRnccpMDTO7DScEhgap6hO48xOA/B7FHgAAAAAwEcEtIhQmz7/Z3YaTonv+4ICWkSYnQbg9yjwAAAAAIAPieo4UpEdR5mdRqNEdhytyA63m50GAFHgAQAAAACf06bP8woM8e1btQJD4xTf53mz0wDwbxR4AAAAAMDHBIXGKb7ffLPTqFd83/kKDI01Ow0A/0aBBwAAAAB8UGSHFLXp/ZzZadSqTe85iuyQYnYaAKqhwAMAAAAAPiqm+1TFXf+E2WlcIe76JxXTfYrZaQD4AQo8AAAAAODDYq+bqTa955idhiSpTe+5ir3uYbPTAFALCjwAAAAA4ONiuk9Ru8GLTJt4OTA0Tu0GL1JM98mmxAfQMAo8AAAAAGABkR1S1GnUJkV2HO3duJ3GqNMdm5hzB/BxFHgAAAAAwCICQ2PVbtBCtR30JwWGNu1onsujdl5Xu4H/j6dlARYQZHYCAAAAAADnRHUcqYh2Q3Th+McqOLJcZQUHPdZ2cEyyYpImKqrTOAW0iPBYuwCaFgUeAAAAALCggBYRatntZ4ruep9K8vaq4PByXcreLKOi2Om2bIFhikxMUcukiQpt/RPZbLYmyBhAU6LAAwAAAAAWZrPZFNamj8La9JFRaVdZ4TGVnv1SJWcPqPTsl7IX5cioLJVRUSZbYLBsASEKCm+nkNieCo3tpZDYngqO7iJbAJeHgJXRgwEAAACgmbAFBCkkprtCYror+prxZqcDwIssN8nyiRMn9Pjjjys5OVkRERGKjY1V37599corr6ioqMhjcTZu3KjU1FQlJiYqJCREiYmJSk1N1caNGz0WAwAAAAAAwBNshmEYZifRWGvXrtUDDzygwsLCWtcnJSVp/fr16tq1q8sxKisr9eCDD2rJkiV1bjN9+nQtWrRIAQGerY9lZ2erQ4cOkqSsrCwlJiZ6tH0AAAAAANA8r78tM4Jn3759mjBhggoLCxUZGal58+Zp586d2rJli37xi19Ikg4fPqxRo0bpwoULLsd55plnHMWdG264QStWrNDu3bu1YsUK3XDDDZKkN954Q7/+9a/d3ykAAAAAAAAPsMwIniFDhuizzz5TUFCQPv30Uw0YMOCK9a+88oqefPJJSdKcOXM0d+5cp2McPnxY1113nex2u/r06aNPP/1UYWFhjvVFRUUaOnSoMjIyFBQUpG+++cat0UI/1BwriAAAAAAA+JrmeP1tiRE8u3fv1meffSZJmjZtWo3ijiQ9/vjj6tGjhyTptddeU3l5udNx/vCHP8hut0uSFi5ceEVxR5LCw8O1cOFCSZLdbtfvf/97p2MAAAAAAAB4miUKPKtXr3YsT506tdZtAgICNGnSJElSQUGBtm7d6lQMwzD08ccfS5KSk5PVv3//Wrfr37+/unfvLkn6+OOPZZEBUAAAAAAAoBmzRIFn+/btkqSIiAj17t27zu2GDh3qWN6xY4dTMTIzM3X69Oka7dQX59SpUzp+/LhTcQAAAAAAADzNEgWeb775RpLUtWtXBQUF1bldcnJyjdc01tdff11rO56OAwAAAAAA4Gl1V0t8RElJifLy8iSpwUmPWrVqpYiICF26dElZWVlOxcnOznYsNxSnaiImSU7FqR6jNtXbysnJaXS7AAAAAACg8apfc1fNxWt1Pl/gqf7I88jIyAa3ryrwXLx4scniREREOJadiVO9MNSQfv36NXpbAAAAAADgmtzcXHXu3NnsNNzm87dolZSUOJaDg4Mb3D4kJESSVFxc3GRxqmK4EgcAAAAAAPiO7777zuwUPMLnR/CEhoY6lsvKyhrcvrS0VJJqPOLck3GqYjgbp6HbuTIzMzVkyBBJ0s6dO50a8QPrycnJcYzU2r17t9q1a2dyRmhKHG//wvH2Lxxv/8Lx9i8cb//C8fYvWVlZuummmyQ1PA+vVfh8gScqKsqx3JjboS5duiSpcbdzuRqnKoazcRqa26e6Dh06OLU9rK1du3Ycbz/C8fYvHG//wvH2Lxxv/8Lx9i8cb/9SfcCHlfn8LVqhoaGKi4uT1PAkxefOnXMUX5wd/VK98zozGTKjbAAAAAAAgNl8vsAjSddee60k6ejRo/XObn3w4EHHco8ePVyK8cN2PB0HAAAAAADA0yxR4Bk0aJCky7dG7d27t87t0tLSHMsDBw50KsbVV1+thISEGu3U5tNPP5UktW/fvlnMtA0AAAAAAKzNEgWeO++807G8dOnSWreprKzUW2+9JUmKiYnR8OHDnYphs9k0btw4SZdH6OzatavW7Xbt2uUYwTNu3DjZbDan4gAAAAAAAHiaJQo8/fr10+DBgyVJS5YsUXp6eo1tXn31VX3zzTeSpEcffVQtWrS4Yv22bdtks9lks9k0ZcqUWuM89thjCgwMlCTNnj27xiPQi4uLNXv2bElSUFCQHnvsMXd2CwAAAAAAwCMsUeCRpNdee01hYWGy2+1KSUnRiy++qF27dmnr1q2aMWOGnnzySUlSUlKSHn/8cZdiJCUl6YknnpAkZWRkaODAgXrvvfeUkZGh9957TwMHDlRGRoYk6YknnlC3bt08s3MAAAAAAABu8PnHpFe54YYb9N577+mBBx5QYWGhnn766RrbJCUlaf369Vc88txZ8+bN0/fff68333xT+/bt07333ltjm2nTpumFF15wOQYAAAAAAIAn2QzDMMxOwhknTpzQa6+9pvXr1ys7O1vBwcHq2rWr7r77bs2aNUvh4eG1vm7btm2OeXkmT56sZcuW1Rtnw4YNWrx4sfbs2aO8vDy1bt1affv21YwZMzRy5EhP7xYAAAAAAIDLLFfgAQAAAAAAwJUsMwcPAAAAAAAAakeBBwAAAAAAwOIo8AAAAAAAAFgcBR4AAAAAAACLo8ADAAAAAABgcRR4AAAAAAAALI4CDwAAAAAAgMVR4AEAAAAAALA4CjxN4MSJE3r88ceVnJysiIgIxcbGqm/fvnrllVdUVFTksTgbN25UamqqEhMTFRISosTERKWmpmrjxo0ei4HaZWRk6De/+Y1SUlIcv//IyEglJSVp6tSp2r59u0fizJ07VzabrVE/27Zt80hM1NTYYzBs2DCPxFuxYoVSUlLUtm1bhYaGqlOnTnrggQeUnp7ukfZRv2HDhjX6mLvT/+jfTe/777/XunXr9Nxzz2nkyJFq3bq143c6ZcoUp9vz1nm3qKhIL7/8svr27avY2FhFREQoOTlZjz/+uE6cOOHRWM2NJ455UVGRPvroIz388MPq27evWrVqpRYtWiguLk4DBgzQ3LlzdebMGY/k27lz50a9B3Tu3Nkj8ZobTxzvZcuWNfq9eNmyZR7JOy8vT88995x+9KMfKTo6WtHR0frRj36k5557Tvn5+R6J0Ry5e7yPHz/u9Pndnb5H/3adp6+1/Or8bcCj1qxZY0RHRxuSav1JSkoyjhw54laMiooKY9q0aXXGkGRMnz7dqKio8NBeobrBgwfX+7uv+pk0aZJRWlrqVqw5c+Y0KpYkY+vWrZ7ZQdTQ2GMwdOhQt+IUFRUZd9xxR53tBwQEGHPnzvXMTqFOQ4cObfQxrzou2dnZTsehfze9+n6nkydPbnQ73jzvHjlyxOjWrVudcaKjo421a9e6Hae5cveY79+/34iMjGywT0ZHRxsrV650O99OnTo16j2gU6dObsdqjjzRx5cuXdro9+KlS5e6nfOuXbuMtm3b1hmjXbt2xueff+52nObI3eOdmZnp1PldkpGSkuJyvvRv13jyWssfz99Bgsfs27dPEyZMUHFxsSIjI/WrX/1Kw4cPV3FxsVauXKm//OUvOnz4sEaNGqWMjAxFRUW5FOeZZ57RkiVLJEk33HCDnnzySXXp0kXHjh3Tyy+/rH379umNN95QmzZtNH/+fE/uIiSdPn1akpSQkKC7775bgwcPVseOHVVRUaH09HS9+uqrOnXqlN566y2Vl5fr3Xff9UjcAwcO1Lv+6quv9kgc1O3hhx/WzJkz61wfERHhVvs///nPtWHDBknS8OHD9eijjyohIUEHDhzQ/PnzdezYMc2dO1ft2rXTgw8+6FYs1G3p0qW6dOlSvdt8/fXXmjBhgiTplltuUfv27d2KSf9ueh07dlRycrI2bdrk9Gu9dd69cOGCRo0apSNHjkiSfvGLX+jee+9VWFiYtm7dqhdffFGFhYWaMGGCduzYoR//+Mcux/IHrhzzwsJCXbx4UZI0cOBAjR49Wn369FFcXJxyc3P10Ucf6S9/+YsKCwt1//33Kzo6WiNHjnQ713HjxumFF16oc31wcLDbMZo7d/p4lX/84x9KSEioc31iYqLLbUtSVlaWxowZo9zcXAUFBem///u/NXr0aEnSunXr9Lvf/U45OTkaM2aM9u7d63a85syV492+ffsGz7eS9OKLLzo+v0+ePNnlHKvQv53jyWstvzx/N3kJyY9UVRuDgoKMnTt31lj/8ssvOyp4c+bMcSnGoUOHjKCgIEOS0adPH6OoqOiK9ZcuXTL69OnjyMPd0UKoadSoUcZ7771n2O32Wtfn5uYaSUlJjmOdlpbmcqzq3/DDPO7228bYsmWLI86YMWNq/H3l5uYaHTt2NCQZMTExxtmzZ5ssFzTsySefdByv5cuXu9QG/bvpPffcc8batWuNM2fOGIZx5be3jf1235vn3WeffdaR38svv1xj/Y4dOxy5uDtisLly95jv2LHDuOeee4yvvvqqzm1Wr15t2Gw2Q5LRpUsXo7Ky0uV8q77hd2ZEGf7DE328+giezMzMpkvWMIyJEyc6Yr3//vs11r/33ntO5+9PPHG8G2K3242EhARDkhEVFVXjPd8Z9G/XeOpay1/P33yq9JDPP//ccVBnzJhR6zYVFRVGjx49HBdoZWVlTsd5+OGHHXHS09Nr3SY9Pd2xzcyZM52OAfetXbvWcQxmz57tcjtcAPoGbxR4Ro4c6TjBZGVl1brNihUr6j15wDsqKiqM9u3bG5KMyMhI49KlSy61Q//2PlcuBrx13i0rKzNatmxpSDJ69OhR53DxGTNmOGLt3r3bpVj+pCkuAA3DMMaPH+9od+/evS63wwWgZ/lygScnJ8cICAgwJBm33XZbndvddttthnT59t+cnJwmy6c5aIr+/fe//93R5tSpU91qi/7ddBpzreWv528mWfaQ1atXO5anTp1a6zYBAQGaNGmSJKmgoEBbt251KoZhGPr4448lScnJyerfv3+t2/Xv31/du3eXJH388ccyDMOpOHDf8OHDHcvHjh0zMRNYwYULF7RlyxZJ0q233lrnkOy77rpL0dHRkqS//e1vXssPV9qyZYtOnTolSfrpT3+q8PBwkzNCU/HmeXfr1q06f/68pMu3BAQE1P4RrfpEorwPmIfzPJy1Zs0aVVZWSqr7WkH6Tx+vrKzUmjVrvJEaqnnrrbccy564PQtNo6H3YH8+f1Pg8ZCqmbwjIiLUu3fvOrcbOnSoY3nHjh1OxcjMzHTck1i9nfrinDp1SsePH3cqDtxXWlrqWA4MDDQxE1jBnj17VFZWJqn+vh0cHOw4Qe3Zs0fl5eVeyQ9Xqv7hr6poj+bJm+fd6k8EqS9Wnz59HEVFZz9HwHM4z8NZje3j7lwrwD0XLlxwfGnfuXNnDRkyxNyEUKeG3oP9+fxNgcdDvvnmG0lS165dFRRU99zVycnJNV7TWF9//XWt7Xg6DtyXlpbmWO7Ro4dH2kxJSVF8fLyCg4MVHx+vYcOGacGCBTp37pxH2kfDPvjgA1177bUKDw9XVFSUunXrpsmTJzs9Gu+HXOnbdrvdMZEbvOfixYuOb106deqkYcOGeaRd+rdv8uZ5t7GxgoKC1LVrV5fjwDM8fZ7/9NNP9eMf/1hRUVEKDw/X1VdfrQkTJmj16tWMxPaiqVOnKiEhQcHBwWrdurX69++vX//6145Rm+6o6uMtW7ZU27Zt69yuXbt2jtG69HHvWrVqlYqKiiRJEydOlM1m80i79G/Pa+g92J/P3xR4PKCkpER5eXmSGp5dv1WrVo4n7WRlZTkVJzs727HcUJwOHTo4lp2NA/dUVlZqwYIFjn/fc889Hml38+bNys3NVXl5uXJzc5WWlqZf/epXuuaaaxxDENG0vv76a33zzTcqLi7WxYsXdfToUb311lu6+eablZqa6hie6Sz6tnV8+OGHjidsPfDAAx778Ef/9k3e7JtVsSIiIhQTE9OoWLm5uVd8iwnv2L9/v9avXy9J6tWrl0cKPJmZmdq/f78uXryo4uJiHT9+XO+//75SU1M1ePBgjxQY0LBt27YpJydH5eXlys/P1+eff6558+apa9euWrRokVttV/XxxjwZq6qPc573rqYaoUv/9qzGXGv58/mbx6R7wIULFxzLkZGRDW4fERGhS5cuOR7D2RRxqj+u2dk4cM/vf/977d69W9LlOVPqu2WvMXr16qU777xT/fr1U0JCgsrLy3Xo0CG988472rRpkwoKCjR+/HitXbvWI49qRU3h4eEaO3asbrnlFiUnJysyMtJxEf7nP/9Z+fn5Wr16tcaNG6fNmzerRYsWTrVP37YOT3/4o3/7Nm/2zapYjf0cUT1WSEiI0/HgmtLSUk2fPl0VFRWSpHnz5rnVXnBwsMaOHauUlBT17NlTLVu2VEFBgdLT0/X6668rKytLO3bs0IgRI5Senq6WLVt6YjfwA9dcc43uuusuDRgwwHEB9u233+rDDz/UqlWrVFJSooceekg2m00PPvigSzFc6eOc573n5MmTjlEhN910k2OkhTvo302jMdda/nz+psDjASUlJY7l4ODgBrevOpDFxcVNFqf6H4uzceC6tLQ0/e///q8kKT4+Xq+//rpb7T322GOaO3dujf+/8cYbNWnSJC1atEgPPfSQKioqNH36dB07dkyhoaFuxURNp06dqrUiP2LECM2ePVsjR47Uvn37lJaWptdff12//OUvnWqfvm0N2dnZ2rZtm6TLk/IlJSW51R792/d5s29WxXLmc4SrseC6WbNmKSMjQ9LlyTTHjBnjVnu7d++u9fwybNgwzZo1Sz/96U+1adMmffPNN3r++ef1u9/9zq14qCk1NVWTJ0+uMSKzb9++mjBhgtatW6e77rpL5eXl+q//+i+NHTu23lus6uJKH6d/e8/bb7/tuF3KU6N36N+e19hrLX8+f3OLlgdU/8BdNVFqfaqGY4WFhTVZnOpDvpyNA9d89dVXSk1Nld1uV2hoqD744APFx8e71WZDw/xmzJihadOmSZJOnz6tDz/80K14qF19x+Gqq67SqlWrHKN2Fi5c6HT79G1rePvttx1PQPHEkzXo377Pm32zKpYznyNcjQXXvPjii3rjjTckXb74/+Mf/+h2m/W9D0RFRen9999XbGysJGnx4sWN+vuAc1q2bFnv7bajR4/Wc889J0kqKirSkiVLXIrjSh+nf3vP8uXLJV2+AJ8wYYJH2qR/e5Yz11r+fP6mwOMBUVFRjuXGDOuqmr+hMcO4XI1TFcOVOHBeZmamUlJSdO7cOQUGBmrlypVem3l/xowZjuXqE47Be6655hqNGDFCknT06FHHrP2NRd+2hqb48NcQ+re5vNk3q2I58znC1Vhw3qJFi/T0009LujyJ5oYNG64Yat9UWrZsqXvvvVfS5eNeNXoI3vXggw86ikCuvhe70sfp396xe/duHTx4UJI0duzYBr+A8RT6d+M5e63lz+dvCjweEBoaqri4OElXTuhUm3PnzjkObPUJnRqj+gRRDcWpPkGUs3HgnNOnT+vWW2/V6dOnZbPZ9Oabb2rcuHFei3/ttdc6lpmkzTzuHAf6tu/LyMhwPCVh9OjRatWqlVfi0r/N5c2+WRXr0qVLKigoaFSsNm3aMP+OF6xYsUIzZ86UdPnpeZs3b1br1q29Fp/3AfPFx8c7Puu7egyq+nhD7yXSf/o453nvaKrJlRuD/t0wV661/Pn8TYHHQ6o659GjR2W32+vcrqo6LDn/WM3qbwDV2/F0HDReXl6eRowYoW+//VbS5dtzvH1i8NRTfOAed46DK307KChI3bp1czkmnFP9w58nbs9qLPq3ubx53m1sLLvdrmPHjrkcB85Zs2aNJk2apMrKSrVr105btmxp1FOQPIn3Ad/g7nGo6uPnz5/XmTNn6twuJydHhYWFkujj3lBeXq6VK1dKulzIu/32270an/5dP1evtfz5/E2Bx0MGDRok6XLlbu/evXVuV31Y58CBA52KcfXVVyshIaFGO7X59NNPJUnt27dX586dnYqDxjl//rxuu+02x7f6CxYs0COPPOL1PKriS3L8fcD73DkOffv2dUzMVl/fLisr065duxyvcfZpXXBN9Q9/bdq08erTrOjf5vLmebfqc0RDsTIyMhwjgZ39HAHnbNmyRffcc4/sdrvi4uK0efNmdenSxet58D5gvtzcXOXl5Uly/Rg0to+7c60A561fv175+fmSpJ/97GcKCvLuM4jo33Vz51rLn8/fFHg85M4773QsL126tNZtKisrHd8Cx8TEaPjw4U7FsNlsjuFoBw8edFzo/dCuXbsc1cNx48ZRGW4CRUVFGjVqlL744gtJ0jPPPKOnnnrKlFwWLVrkWB46dKgpOfi7zMxMbd68WZLUpUsXtW/f3qnXR0VF6ZZbbpEkffLJJ3UOJf3oo48c3+qlpqa6kTGcsXHjRuXm5kry/oc/+re5vHneHTZsmOMRuX/9618dT3P5oWXLljmWeR9oOjt37tS4ceNUWlqqli1b6h//+Ieuu+46r+dx/vx5R4E5PDxcffr08XoOuDwBblWfdPW9eOzYsQoIuHzpVde1gvSfPh4QEKCxY8e6FAuNZ9YIXYn+XR93r7X8+vxtwGMGDx5sSDKCgoKMnTt31lj/8ssvG5IMScacOXNqrN+6datj/eTJk2uNcejQISMwMNCQZPTp08coKiq6Yn1RUZHRp08fRx6HDx/2xK6hmtLSUiMlJcVxrB599FGX2lm6dGm9fw//+te/jCNHjtTbxqJFixxttG3b1rh48aJLuaBua9asMcrLy+tcf+bMGeOGG25wHIdXX321xjYNHWvDMIwtW7Y4thk7dqxht9uvWJ+bm2t07NjRkGTExMQYZ8+edWu/0Hjjx493HJu9e/c26jX0b9+UmZnZ4Hn2hzx13p08ebIj9tatW2vd5tlnn3Vs8/LLL9dYv3PnTiMoKMiQZAwdOrRR+fs7V475vn37jJiYGEOSERERYWzfvt2l2EOHDnXEzszMrLF+48aNNf6eqrtw4cIVnzdmz57tUh7+xNnjnZmZaXzxxRf1brN27VojODjYkGSEhYUZ2dnZtW7X0PE2DMOYOHGiY5sPPvigxvr333/f6b9Xf+ZK/64uPz/fcWx79erl1Gvp303HU9da/nr+9u4YtGbutdde08CBA1VcXKyUlBQ9/fTTGj58uIqLi7Vy5UotXrxYkpSUlKTHH3/cpRhJSUl64okntGDBAmVkZGjgwIF66qmn1KVLFx07dkwvvfSS9u3bJ0l64oknmKOjCdx3333atGmTJOnmm2/WtGnT9OWXX9a5fXBwsJKSkpyOs3fvXk2fPl3Dhw/XyJEj1atXL8XFxclut+vgwYN65513HHkEBgZq8eLFXnmih7+ZPXu2ysvLNX78eA0YMECdO3dWWFiY8vLytG3bNi1atMgxbHvQoEEu36Z38803695779XKlSu1Zs0ajRgxQo899pgSEhJ04MABzZs3TydPnpQkvfTSS16b5NffnTt3TuvWrZMk9ezZUz/5yU880i792zu2b9+uo0ePOv5d1Vely3PmVf82TZKmTJlSow1vnnefeOIJvffeezp8+LCefPJJHT16VPfee6/CwsK0detWzZ8/X3a7XWFhYfrDH/7gcpzmzN1jfuzYMd12222OiTJfeOEFtWzZst7zfHx8fJ2P6q3PggULdP/99+uuu+7SoEGD1KVLF0VGRur8+fPauXOn/vznPzve97t37665c+c6HaO5c/d4Hz9+XMOHD9eAAQM0ZswYXX/99Y5j+e2332rVqlVatWqV4xv53/72t06P0q1u3rx5+vvf/67c3Fzdd999ysjI0OjRoyVJ69at06uvvirp8u3AL7zwgstxmitPvKdXt3LlSsejrT09eof+7TpPXWv57fm7SctHfmjNmjVGdHS0o4L3w5+kpKQ6v7VtzAgewzCMiooK4+c//3mdMSQZ06ZNMyoqKppoL/1bfb/32n46depUazsNfcNffX19P3Fxccbq1aubdqf9WKdOnRp1HMaPH2+cO3eu1jYaM4LHMC5/k3DHHXfUGSMgIKDe18PzXn/99Xq/kakL/ds3VP/WrTE/dfHEebcx3wAahmEcOXLE6NatW51xoqOjjbVr17rza2nW3D3mje2b1X/qel9u6Bv+6uvr+xk6dGido0b8nbvHu/pn7/p+wsPDjUWLFtWbS2NG8BiGYezatcto27ZtnbHatm1r7Nq1y91fTbPkqff0KjfeeKMhyQgMDDRycnKcyoX+3XScfQ+u61rLMPzz/M0IHg8bM2aM/vWvf+m1117T+vXrlZ2dreDgYHXt2lV33323Zs2apfDwcLdiBAQEaMmSJRo/frwWL16sPXv2KC8vT61bt1bfvn01Y8YMr04CiqZxxx13aMmSJUpPT9e+ffv03XffKT8/X4ZhKDY2Vtdff71uv/12TZkyRdHR0Wan22z99a9/VVpamtLT0/Xtt98qLy9PhYWFioyMVIcOHXTTTTdp8uTJGjBggNuxwsLCtH79er377rtatmyZ9u/fr4KCAl111VUaPHiwZs2a5ZE4aLzly5dLujyK5v777/dYu/Rva/Hmebdr167at2+f/vjHP+qDDz7Q0aNHVVZWpg4dOuiOO+7Qo48+qk6dOnkkFsz129/+Vlu2bFF6eroOHTqkvLw8FRQUKDw8XAkJCbrxxht13333KSUlhfkUm0jv3r319ttvKz09XRkZGcrJyVFeXp7sdrtatWql6667TrfccoumT5/u0iit2tx44406cOCAXnvtNa1evVrHjx+XdHlS2HHjxumxxx5zPJIdTefIkSP6/PPPJUkjRoxQ27ZtPdo+/ds3+OP522YYdcwCBAAAAAAAAEvgKVoAAAAAAAAWR4EHAAAAAADA4ijwAAAAAAAAWBwFHgAAAAAAAIujwAMAAAAAAGBxFHgAAAAAAAAsjgIPAAAAAACAxVHgAQAAAAAAsDgKPAAAAAAAABZHgQcAAAAAAMDiKPAAAAAAAABYHAUeAAAAAAAAi6PAAwAAAAAAYHEUeAAAAAAAACyOAg8AAAAAAIDFUeABAAAAAACwOAo8AAAAAAAAFkeBBwAAAAAAwOIo8AAAAAAAAFgcBR4AAAAAAACLo8ADAAAAAABgcRR4AAAAAAAALI4CDwAAAAAAgMVR4AEAAAAAALA4CjwAAAAAAAAW9/8BcIOb/+9zcgcAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "height": 434,
+       "width": 572
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.scatter(*zip(*fp.points[:4], strict=True), s=600, color=\"cadetblue\", zorder=1)\n",
+    "plt.scatter(*zip(*fp.points[4:], strict=True), s=300, color=\"goldenrod\", zorder=2)\n",
+    "plt.scatter(*zip(a, b, strict=True), color=\"red\", ec=\"k\", zorder=3)\n",
+    "plt.xlim(0, 20)\n",
+    "plt.ylim(0, 20)\n",
+    "plt.title(f\"Closest pair is {dist:.2} units apart.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa581029-388f-4b6b-ac0e-0cd4e39aedcd",
+   "metadata": {},
+   "source": [
+    "Add another 4 2D points and query again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "9cf2120b-3f9c-47a7-9398-72d5c41605b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.222902Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.222831Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.225882Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.225687Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.222895Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1.0, ((8, 10), (9, 10)))"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for p in range(4):\n",
+    "    fp += tuple(*random_points(p + 2**p, (2), 1))\n",
+    "\n",
+    "dist, (a, b) = fp.closest_pair()\n",
+    "dist, (a, b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dab306cd-c44a-4212-8117-f395d20b9977",
+   "metadata": {},
+   "source": [
+    "The closest pair has once again been updated!\n",
+    "\n",
+    "Vizualize the current set.\n",
+    "\n",
+    "* 4 initial points in `\"cadetblue\"`\n",
+    "* First set of 4 additional points in `\"goldenrod\"`\n",
+    "* Second set of 4 additional points in `\"darkolivegreen\"`\n",
+    "* Current closest pair in `\"red\"`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "0255e23a-180c-4a17-a386-e8e3206dd9f5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-06-12T02:00:48.226275Z",
+     "iopub.status.busy": "2024-06-12T02:00:48.226215Z",
+     "iopub.status.idle": "2024-06-12T02:00:48.319771Z",
+     "shell.execute_reply": "2024-06-12T02:00:48.319561Z",
+     "shell.execute_reply.started": "2024-06-12T02:00:48.226269Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABHgAAANlCAYAAAAHHU6IAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy80BEi2AAAACXBIWXMAAB7CAAAewgFu0HU+AAC9y0lEQVR4nOzdeVjVZf7/8ddhk01BwAUUBTXAXUvM1MIsNUtzybRlUptmqpmppr79qpmpsZz2vamZttHSbLNVy7KyUhu3BHMXQQ0SBBVQVBZlOZ/fH+YZkO0ABz7nA8/HdXF5Duc+9/0+BzhyXtyLzTAMQwAAAAAAALAsD7MLAAAAAAAAQOMQ8AAAAAAAAFgcAQ8AAAAAAIDFEfAAAAAAAABYHAEPAAAAAACAxRHwAAAAAAAAWBwBDwAAAAAAgMUR8AAAAAAAAFgcAQ8AAAAAAIDFEfAAAAAAAABYHAEPAAAAAACAxRHwAAAAAAAAWBwBDwAAAAAAgMUR8AAAAAAAAFgcAQ8AAAAAAIDFEfAAAAAAAABYHAEPAAAAAACAxRHwAAAAAAAAWBwBDwAAAAAAgMUR8ABACzJ79mzZbDbZbDYtWLDA7HLQQixYsMDxfTV79mzT6hg1apSjjlWrVplWB6zHXb6HAQBoSl5mFwAAkI4fP67ly5drxYoVSkpKUk5OjnJzc+Xj46P27dsrJiZG8fHxuvLKK3XBBReYXS6As2RlZSkxMVGJiYlKSkpSYmKijhw54rg9LS1NUVFRTV5HYmKi3nzzTa1atUqZmZmSpK5du2rUqFG68cYbFR8f3+Q1AAAAczCDBwBMVFRUpMcee0xRUVG65pprNH/+fG3dulVZWVkqKSlRQUGBMjIy9N133+mJJ57Q8OHDFRsbq/fee0+GYZhdfqvArCjUJSIiQl26dNHkyZP16KOP6uuvv64U7jSHkpIS/fnPf9b555+vV155RcnJyTpx4oROnDih5ORkvfLKKzr//PN11113qbS0tFlrs4r09HTHz3pzhHFoeszcAtDaMIMHAEyyf/9+TZw4Udu2bav0+W7dumnAgAHq0KGDysvLdfDgQW3dulWHDh2SJKWmpuq6665TRkaG7r33XjNKB1BBdna22SXo97//vd566y3H9R49emjYsGGSpA0bNujnn3+WYRh64YUXdPz4cc2fP9+sUgEAQBMh4AEAE6Snp+uCCy7QwYMHJUk2m03XXnut/va3v6lv375V2huGoaSkJL300kt65513ZLfbVVRU1Nxlo5WaPXu2W/z125333fH19dWgQYMUHx+v+Ph4derUSePGjWuWsd944w1HuOPh4aFnn31Wd9xxhzw8Tk/UttvtevHFF3X33XfLbrfrjTfeUEJCgmbOnNks9bkDd/keBgCgKRHwAEAzKykp0dVXX+0Id3x9ffXee+9p8uTJNd7HZrMpPj5eb731lu69915de+21zVQtgLr89NNP6t+/v7y8/vdrVXp6erOMferUKT300EOO6/fee6/uvPPOSm08PDx055136uDBg3ryySclSXPmzNE111wjHx+fZqkTAAA0PfbgAYBm9tRTTykpKclxfeHChbWGO2fr16+fNmzYoDFjxjRBdQDqa/DgwZXCneb02WefKSMjQ5IUFBSkv//97zW2nTNnjtq1aydJ+uWXX/TFF180S40AAKB5EPAAQDMqLi7Wiy++6Lg+depUTZ8+vd79BAQEaMSIEY2up6CgQC+++KLGjRunrl27ytfXV+3bt1e/fv1022236ccff3S6r4yMDM2dO1cXXXSROnXqpDZt2sjHx0ehoaEaOHCgrrvuOr3yyiuOmUu1MQxDn376qWbNmqWYmBgFBQXJ19dXkZGRmjx5shYuXKiysjKn6tq9e7fuvfdeDRs2TGFhYfLx8ZGvr686duyo8847TzfeeKMWLlyoo0ePVrpfVFSUbDabFi5c6PjcjTfe6Niws+JHxRkU9VHTpq7fffedrr32WvXs2VN+fn7q0KGDLrzwQv3rX//SqVOnnOr78OHDevPNNzVr1iwNHjxYISEh8vb2VnBwsOLi4nTjjTfq66+/dqovZzYqXbVqlaPNqFGjHJ//8ssvde211+qcc85RYGCgbDabXnjhBafGPZuzx6SXlpbq7bff1tSpU9WjRw8FBgbKy8tLbdu2Va9evTRu3DjNmTNHGzdubFAd7mTJkiWOyzNmzJC/v3+Nbf39/Su93nz66aeNHv/Mz4nNZnNq1pIzm5ZX16aoqEgvv/yyRo4c6Xh9iYyM1LXXXqu1a9fWOW5t38NnbouOjnZ87pdffqn2Z91ms1Xbf2Jiom677Tade+65at++vby8vOTn56fw8HANGzZMf/jDH/TBBx+osLCwzlqdsWnTJj3++OOaMGGC43vcx8dHnTp10vDhw3X//fdr//79TvVV3ddw9+7duvPOO9WnTx+1a9dO7dq104ABA/TAAw849Rounf7/bsmSJbrjjjscXzcfHx8FBgYqKipKU6ZM0fz581VSUlJnX/V9fTnzPXTjjTc62i5cuLDar2fF/gDA8gwAQLN56623DEmOjzVr1ri0/1mzZjn6fvPNN2tt+/nnnxudO3euVE91H9ddd51RWFhYa1+vvfaa4efnV2dfkowRI0bU2tfWrVuNQYMG1dlPbGyssXPnzlr7evDBBw1PT0+n6rr++usr3bd79+5O3U+S8eCDD9ZaR03S0tIcfXTv3t0oKSkxbr755lrH6t27t5GSklJrv//85z+dftyjR482cnNza+3vzTffdLSfNWtWtW1WrlzpaJOQkGDk5+cbU6ZMqXbM559/vkHPV0JCgqOPlStXVtsmJSXF6N27t9Nfuz179jSolrpU/NpKMtLS0ppknPDwcMcY7777bp3t33nnHUf7Ll26NHr8ij8nzjxGZ16jzm6zc+fOOr+mc+bMqXXc2r6HK97mzEdFpaWldf7MVvy4//7763yO6hIfH+/UWN7e3saTTz5ZZ39nfw1ff/11o02bNjX22759e2Pp0qW19rlhwwYjMDDQqTqjoqKMn376qdb+6vv6UvF7qK6PhISE+jz9AODW2IMHAJrR999/77jcrVs3l8zCaYjFixfr+uuvV3l5uSTJ09NTI0eOVK9evVRQUKD//ve/ysrKkiS9++67SktL0/fffy9fX98qfS1ZskS33HKL43q7du10wQUXqGvXrvLy8tKxY8eUmpqqHTt21PmX2h9++EETJ07U8ePHJUne3t6Kj4/XOeecI29vb6Wnp2vNmjU6efKkUlJSNHz4cK1fv169e/eu0tc///lPzZ0713E9LCxMw4YNU3h4uGw2m44cOaLdu3crOTnZ8TxUNGvWLOXl5em7777T7t27JUmXXHKJ4uLiqrQdOnRorY/LWffdd59ef/11SdKAAQM0aNAgGYahTZs2adeuXZKk5ORkjR49WuvXr1dkZGS1/WRlZTkeU48ePdS7d2916NBBvr6+ys/P1/bt27Vz505Jp78nL730Um3YsEFt2rRxyeMwDEO/+c1vtGzZMtlsNg0ZMkR9+vSRYRjasWNHjbMgGuvEiRO69NJLHUuWPDw8NHjwYPXu3VuBgYEqKirSgQMHtHXrVuXm5jZJDc3p2LFjlU7wOvfcc+u8T8U2Bw4c0PHjxx3LttxRVlaWLr30UmVnZys4OFgXXnihOnfurNzcXH3//fc6duyYJOkf//iH+vTpoxkzZtR7jN69e+tPf/qTTpw44disum3btk5tQn3PPfc4fmYlqUuXLho6dKg6dOggu92uvLw87dq1SykpKfWuqyZnZua0adNGffv2Va9evRQUFCTDMJSdna0ff/xRubm5Ki0t1X333SdJTp+4uHTpUsceTl26dNHIkSMVGBio1NRUrV27Vna7XUePHtW0adP0+eef17iR+NGjR1VQUCBJ6tixo/r27auuXbsqICBARUVF2rt3rzZu3KiysjKlp6crISFBP/30k3r16lVnjc68vlx66aUKDAzU7t279d1330mS4uLidMkll1Tp75xzznHquQEASzAzXQKA1qZnz56OvxpeffXVLu/fmb+O7927t9JfVocOHVplFkN5ebnx7LPPGh4eHo52t99+e7X9VZxtc9ttt9U42+fEiRPGBx98YNx3333V3p6dnW107NjR0dfMmTONrKysKu0OHjxY6S+3/fv3N8rKyiq1KS0tNcLCwhxtHn/8caOkpKTacfPy8ow33nijxr9012dWVH1VnOXh7e1tSDJCQ0ONr7/+ukrbzz77zGjXrp2j/bhx42rsd/78+cZLL71kZGZm1thm69atxpAhQxz9PfzwwzW2re8MHi8vL8fXZtu2bVXanjx5ssaxalPXDJ4XXnjBcXufPn2M3bt3V9uP3W43Nm7caPzhD38w9u/f36Ba6tIcM3h+/PHHSmMUFRXVeZ/CwsJK99m4cWOjamjqGTxnZpLcd999VV5b8vLyjNGjRzva9ujRw7Db7dX26cz38Nkz6uqSm5vr+F739PQ0FixYUOP4WVlZxosvvmjMmzevzn7r8oc//MH44osvavx6l5WVGW+++aYREBDgeG35+eefa+yv4tfQx8fH8PDwMJ599lmjvLy8UrudO3caffv2dbTt3LmzceTIkWr73LBhg/G3v/3N2L59e43jHjp0yLjhhhsc/V1yySU1tm3o64szX3cAaEkIeACgGZ35xVSS8dBDD7m8f2fePM2cOdPRplevXkZ+fn6N/T333HOOth4eHlXeJJw4ccJxe2RkZI1vbpzx29/+1tHXHXfcUWvbsrKySm/s3n///Uq3b9++3XFbXUvC6tJcAc+Z53jt2rU1tl+xYkWl9t99912jxs/Pz3cs0wsPD68SlJ1R34DnzJu/nJycRtV3troCnquuuspx+4oVK1w6dn01R8Dz5ZdfOvpv166d0/dr27at435fffVVo2po6oBHkvHXv/61xv4OHjzoCDIkGRs2bKi2XVMEPJ9//rmj/dlLPN3B+++/76jv3nvvrbHd2ctRn3jiiRrbZmdnVwrP//73vze6zvHjxzv627VrV7VtGvr6QsADoLVhk2UAaCbHjx+vtDFwcHBws9eQn5+vxYsXO64/9dRTCgoKqrH9n//8Z/Xt21eSZLfbKy1FkORYSiVJoaGhDV56k5OTo7fffluS1LlzZ8dRzjXx9PTUo48+6rj+zjvv1FhXhw4dGlSTGa6//noNHz68xtsvvfRSTZ061XH9P//5T6PGCwoK0pQpUyRJ2dnZjmVgrjBnzhyFhYW5rD9nWPXr3lBnlsBIkp+fn9P3q9i2Yh/uqEOHDpozZ06Nt3fq1ElXXHGF43pzbpzt7t9v06ZNU2BgoCTp22+/deo+0dHRuvvuu2u8vXPnzpW+HvPnz5dhGI2qs+Km187WacbrCwBYAXvwAEAzOXHiRKXrZ37xbk7r1q1znMIUFhamiRMn1trew8NDv/3tbx2/8K9cubLS7WFhYfL19dXJkye1Y8cOrV27tkH7Cn377beO/XmmTp1a7V4/Zzv//PMVEBCgwsJCrVmzptJtFfemWblypVJTUxUTE1PvupqbM3t+zJo1S5988omkql+P6hw+fFgbNmxQcnKyjh49qsLCwkpvyJKSkhyXt2zZov79+zeg8qoashdKY1X8ur/66qt65ZVXmr2G5nTy5EnHZR8fH6fvV3GvpeLiYpfW5GoTJ06s8/Vg8ODB+uCDDyTJqZO8XKXi99snn3yiv/71r+rYsWOzjS9J27Zt0+bNm5Wenq7jx49XOWXvTOi+fft22e12eXjU/rfd6667Tl5etb89+M1vfqO77rpL5eXlysrKUkpKSrV7k51RVFSkDRs2aPv27crJydGJEycq7Xt24MABx+UtW7bUOvYZZry+AIAVEPAAQDNp27Ztpetm/OV88+bNjstDhw6t8xd5SZUCm82bN8swDMebBh8fH02ePFnvv/++ysrKNHr0aM2YMUPTpk3TRRdd5PQspfXr1zsub9u2TbfddpuTj+i0M8FFQECApNNvvIYNG6YNGzbo2LFjOu+883TDDTdoypQpGjFiRK1HSZvFZrPp/PPPr7PdBRdc4Lh86NAhZWdnKzw8vEq7Xbt26b777tPy5cur3US6Oq7aeDg6OlohISEu6as+pk+frjfeeEPS6YBn06ZNmjVrlsaNG+fU5q1WUzH4cOao6TMqhgD1mfljBmcCx9DQUMflirNqmtqwYcMUGRmpjIwM7d+/X3379tWNN96oiRMn6vzzz69X6FZfCxcu1GOPPabU1FSn2peWlurYsWNq3759re0qvr7UpH379oqNjXXM+Nu8eXO1Ac+RI0c0Z84cvfXWW1X+wFETZ16DzHp9AQArIOABgGbSrl07eXl5OZZp5efnN3sNOTk5jsvdu3d36j5RUVGOyyUlJTpx4kSlU3eef/55bdq0SXv27FFJSYkWLVqkRYsWycPDQ3379tWFF16oMWPGaPz48TWe0nTmxC5JWrNmTZUZOc44evSoI+CRTi8dGD16tA4dOqSCggK98soreuWVV+Tl5aVBgwbpoosu0rhx43TJJZfI09Oz3uO5Wvv27auEgNU5cxrWmdkbOTk5VQKer7/+WpMmTary1/y6OPsmzJkazTBu3DjdfvvteumllyRJiYmJSkxMlHR6Kc/IkSM1atQoTZ48WV27djWlRleqOAuwPjNxKrY1YyZhfdS2hPQMb29vx+XS0tKmLKfKuIsWLdKECRNUUFCg3NxcPf3003r66afl6+urIUOG6KKLLtLll1+u4cOHu+T0OMMwdNNNN+nNN9+s931PnDhRZ8DTrVs3p/rq1q2bI+Cp+P/KGb/88osuuugix4lf9amxLu64HA4A3AV78ABAM6oYqrhyvxNnVZw1VDEMqc3Z7c7+Bbxz585KSkrSAw88oE6dOjk+b7fbtX37dr388suaMmWKwsPD9cQTT1Q7m+TMUceNUXF/I0nq06ePtm7dqttvv73Sm8SysjIlJSXpueee07hx49S9e3fNmzev0eM3Vn1mFVX8mpz99cjJydGMGTMc4U737t31+OOPa82aNcrKylJRUZHsdruM0wct6MEHH3Tc1263N/JRnGbmrJAXX3xRn3zySZWj6w8dOqSPP/5Yt99+u7p166Zp06bV+82nuzl75krFJVs1KSoqqvQ94+4zIVwRijSlhIQEbd26VTNnzqz0fX/y5EmtWbNGjz32mEaOHKm4uDgtWbKk0eP95z//qRTuXHbZZVq4cKG2b9+uo0eP6tSpU46fbcMwKv2f48zPt7OvQ7W9Bkmnl3qd+flq27at7rrrLn311Vf6+eefVVBQoPLyckeNFZeaOlOju886AwAzEfAAQDMaOXKk4/KPP/7Y7ONX/Gt9YWGhU/c5u111s0zatWunhx9+WAcOHNCGDRv09NNPa/LkyZU2wTx69Kj++te/6qqrrqqyKWfFNwvPPfdcpTcozn5UnGl0RqdOnfTiiy/q0KFDWrVqlR5++GGNHz++0gykAwcO6Pe//73uuOMOp56PplJUVOR024pfk7O/Hv/5z38cgdnAgQO1bds2/eUvf9GIESMUHh4uPz+/Sm+aXTVrx51MmTJFP/74o3755RctXLhQt9xyi/r06eO43TAMffzxxzr33HOdXuLijmJjYytd/+WXX+q8z9mh1tl9NDVXhYjupEePHlq4cKFycnL01Vdf6YEHHtDFF19cKYhITU3VlClT9NxzzzVqrGeeecZxee7cuVq+fLlmzpypfv36KTg4uMqysPr+fDv7OlTba9C6deu0bt06Saf/z9mwYYMjUI+OjlZAQEClvYBa4msQAJiFgAcAmtHo0aMdl3/55RfHL8HNpeLUdmdnL1TctNTHx6fWZUSenp46//zz9f/+3//Tp59+qkOHDum///2vrrzySkebpUuX6uOPP650v4ozfw4ePOhUXfXRpk0bJSQk6IEHHtCXX36p3NxcLV++vFLg9tJLLzmW85jh6NGjTu3LlJubW2mmxtknyXz33XeOyw888EClMKs6zoQCVtWtWzfNnDlTr776qnbu3Kn9+/dr7ty5jlkKeXl5+r//+z+Tq2y4oKCgSsvzKu6xVZOffvrJcblLly51fn/UpeLyqLNn0VXHFbP13FVAQIDGjRunhx9+WN9//73y8vL04YcfVtpH6K9//WulTYXrIyMjQ3v27JF0+hTGv/71r7W2P378uI4ePVqvMZz9fyEjI8NxubbXoFmzZlUKV6vTkl+DAKC5EfAAQDO6+uqrK/0y3Ni/5tbX4MGDHZc3btzo1Oa7FUOowYMH12vJhIeHh0aOHKklS5ZozJgxjs9/9tlnldpV3Fx47dq1TvffUN7e3rrsssv07bffql+/fo7Pf/7551XaNtcSEcMwnJrVVXFD6k6dOikiIqLS7RX3M6prg9ry8vJmeb7dRWRkpObMmaPXX3/d8blvvvmm3nsVuZOLL77YcXnVqlV1tl+9erXjcsXAuaEqBkR5eXl1tt++fXujx2wqrv5Z9/Pz07Rp07Rq1SpHiF1SUqKvv/66Qf1V/NmOi4urFK5VZ82aNfU+wnzDhg11tsnPz9fu3bsd188999wa63Rmk+wffvihHhXWj7sv8QMAVyPgAYBm5OfnV2kp0Mcff1xlNoszCgsLGzT7Z/jw4Y6NjnNycvTFF1/U2t5ut1fa76GhbwhtNlulI9kPHTpU6fZx48Y5TvRat26dtm7d2qBx6qtNmzYaO3ZsjXVJlU8qauoNXBctWlRnm7feestxueKb+zMqLn2oa7nFkiVLmmTGlLurOKOstLRUR44cMbGaxpk8ebLj8uLFi2vdbLm4uNhxnPjZ922oiksj6zriOikpSWlpaY0es6k01c96SEhIpdMIq3udcUZ9frYl6ZVXXqn3GO+9916dwf8777zjaBMeHl5lmV996szKytLSpUvrXaezmvP1GwDcAQEPADSze++9t9JfPG+44YZqZ47UZMeOHRo2bJi++eabeo8dHBysGTNmOK7fc889te5/8K9//cvxF3cPDw/dfPPNlW4/ceKE08czV5zS37Fjx0q3denSRb/5zW8knZ7JMnPmTKePO7bb7VVOcTl69KjTe33UVpdUeSPbhi6tcNbbb79d6yyelStXVgoEf/e731Vp06NHD8fls2dKVZSTk6O77rqrgZW6J2ePea/4Nffw8Kj0NbaaK6+80nEiWH5+vh599NEa2z788MOO0/u6d++uCRMmNHr8irPvFi5cWGO7srIy/fnPf270eE0pODjYEU7k5OTUGQg4M2PpjLpeZ5wRHR3tmJGyY8cO/fzzzzW2Xbx4sZYtW1bvMfbt26fnn3++xtsPHTqkf/zjH47rN910U5VZMs6+BpWXl+vmm292+v+QhmjO128AcAcEPADQzNq0aaMPP/zQ8Ut+cXGxJk+erJkzZyo5Obna+xiGocTERM2aNUsDBw7Ujh07Gjz+nDlzHJstp6amaty4cVXeKNjtdv3zn/+stD/Jn/70pyobGW/atElRUVF66KGHajwVrLy8XIsXL3YcXS1J48ePr9Lu0Ucfdewnsm3bNg0dOrTWECszM1PPP/+8YmNjtXjx4kq3LV26VDExMXrmmWcq7SFU0alTp/Svf/1LH330Ua11VVzCtXTp0iZ7M+Lt7a3y8nJNmDBB3377bZXbv/jiC02ZMsWx5GLMmDG65JJLqrSrOFPq8ccf19tvv12lzU8//aSEhARlZGQ4fZqaFVxwwQW67rrrtHz58hq/TqmpqZo1a5bj+iWXXFJlY1p3MGrUKNlsNtlsNo0aNarGdm3atNHcuXMd1x9//HG9+OKLlQJOu92uF198UU8++aTjc//4xz9c8rhnzJjhCEXWr1+vv/zlL1VmgGRmZmrChAlat26dYwahO2rTpo3OOeccSadne9R16tVLL72kQYMG6ZVXXqlxJlxBQYHuv/9+x/5enp6elWYN1kdYWJiGDRsm6fTXdNq0aUpJSanUxm6369///rduuOEGeXp6VprB4gwfHx/dd999+uc//1klJE9OTtaYMWN0+PBhSaeXiFYXEl9xxRWO0GfVqlX6f//v/1WZWXbw4EFdddVV+uKLL5r0Naji6/ePP/7o9B5DUVFRjp+/2bNnN1F1AOB6XmYXAACtUY8ePfTjjz9q4sSJ2rFjh+x2uxYtWqRFixYpKipKAwYMUFhYmMrLy3Xw4EFt2bKlyrT+2jY7rk3Pnj01b948XX/99SovL9f69esVGxurCy+8UD179lRBQYH++9//Vvpr57Bhw/TUU09V2192drbmzp2ruXPnqnPnzho0aJA6d+4sLy8vHTp0SJs2baq0J8OFF16oa665pko/ERERWrp0qS6//HLl5uYqJSVF48aNU5cuXTR06FB16NBBpaWlys3N1Y4dO+pc6rFv3z7dc889uueee9StWzcNGDDAEaodPHhQGzZsqLQ05/rrr9fw4cOr9DN+/Hj5+fmpuLhYW7ZsUe/evTVq1CgFBwc73sSMHTu2wW/aKj7+KVOm6IUXXtCYMWM0cOBADRo0SIZhaNOmTdq5c6ejbXh4uP7zn/9U28+sWbP07LPPKjU1VadOndINN9ygxx57TAMHDpSvr6927NihpKQkSadP2Ro3blyNX1urKS0t1Xvvvaf33ntPfn5+GjBggHr06KF27drp6NGj+vnnnx2PXTq9ZLLiqUQN9eqrr+rVV1+t9LmzA6bLL7+8SqBy66236tZbb230+L/97W+1atUqLVq0SHa7XX/+85/14osvOsKADRs2aN++fY72N954o2bOnNnocaXTM4FuvfVWvfzyy5KkJ598Uu+9954uuugi+fr6at++fVq7dq1KSkp06aWXqnPnztWGju7iqquu0mOPPSbp9GvCggUL1KtXr0r73VT8ntm6dav++Mc/6k9/+pN69uypfv36KSwsTKWlpcrOzta6desqbZ7+l7/8RZGRkQ2u7+GHH9bYsWNlt9u1efNm9e/fXyNGjFCPHj0cr93Z2dmSTofmr7/+er02MX7qqad055136s4779QzzzyjkSNHKjAwUKmpqVqzZo0j9PHy8tIbb7yhkJCQKn3ExcXphhtucCwnffbZZ/Xuu+8qPj5eHTt2VHp6un744QeVlJSobdu2evrpp13yc1Cdzp07a/jw4Vq3bp1OnjypgQMH6rLLLlN4eLgjmOzZs6f+8Ic/NMn4ANDsDACAaU6cOGH84x//MIKDgw1JTn0MHDjQ+PTTT6vtb9asWY52b775Zq1jf/7550anTp3qHO/aa681CgsLq+1jw4YNhpeXl9O1T5s2zTh+/HitdaWnpxuXXHKJ03126tTJ+Oqrryr18eGHHxo2m82p+3t4eBh//OMfjZKSkhpreuWVV2rt78EHH6z1MdUkLS3N0Uf37t2NkpIS46abbqq13tjYWCM5ObnWflNSUowePXrU2s+IESOMzMxM48EHH6zzcbz55puONrNmzaq2zcqVKx1tEhISGvR81CUhIcExxsqVK6vc3q9fP6e/b6Kjo421a9e6pK6Kz2F9Pmr7vqn4WJ15Pk+dOmXcdttttX6f2mw244477qj1e70hiouLjcsvv7zWxzphwgTj6NGjTr1G1ed1zDCc+/50po1hGEZ+fr4RFxdX62M545lnnnH6a+3j42PMnTu3zsfijFdeeaXW110PDw9jzpw5ht1uN7p37+74fFpaWrX9nd3mlVdeMXx8fGrsPzg42Pjkk09qrbGwsNAYO3Zsrc9J165djTVr1jj12tGY15fExESjbdu2NdZRXX8Vn5Pavl8AwN0wgwcATBQYGKi///3vuuOOO/Tll19qxYoV2rRpkw4fPqwjR47Ix8dHISEhiouL0/nnn6/JkydXObGkoSZMmKC9e/fqjTfe0LJly7Rz507l5ubKz89PERERuvjiizVz5sxKe2yc7fzzz9fhw4f17bffas2aNdq8ebP27dunvLw8lZeXq127durZs6eGDRum3/zmNxo6dGiddXXv3l3ffvut1q9frw8//FA//PCDMjIydPToUXl5eSk0NFTnnHOOhgwZorFjx2rUqFGODZrPmDZtmrKzs/XNN99o7dq12rp1q37++WfH/iNBQUGKiYnRyJEjNXPmzDqP8b311lvVv39/vfbaa/rxxx914MABFRUV1fuEmrp4e3tr3rx5uvrqqzV//nwlJiYqOztbAQEB6t27t2bMmKGbb765zmUuMTEx2rx5s/7973/rk08+UUpKikpKStS5c2f1799f1113naZPny5PT0+X1m+2LVu2aMOGDVq5cqU2btyolJQUZWVlqaioSP7+/o4ZZldeeaWmT5/u1suF6svHx0cvvfSSbrjhBr3xxhtatWqVYxZely5dNGrUKN10002Kj493+di+vr5atmyZ3nvvPS1cuFA//fSTjh07po4dO2rgwIGaPXu2pk2bZokTjYKCgpSYmKiXX35ZX3zxhZKTk5Wfn1/tfjx33323rrrqKq1YsULr1q3T9u3blZ6eruPHj8vDw0PBwcHq3bu3Ro8erZkzZ6p79+4uqfHWW2/ViBEj9Pzzz2vlypXKysqSn5+funTpotGjR+u3v/1tpRMTG9L/hRdeqFdffVXffvutMjMzJZ1etjRx4kTdfvvtjuW0NfH399fy5cv17rvvauHChdq8ebOOHz+usLAw9ejRQ1dddZVmz56t9u3bO3X6W2MMGTJE27Zt00svvaSVK1fq559/VkFBgVOnSAKA1dgMV/92CgAAnJKenq7o6GhJp4OtmvYLAoCmEhUV5VjGlZaWVmWvNQCAdbDJMgAAAAAAgMUR8AAAAAAAAFgcAQ8AAAAAAIDFEfAAAAAAAABYHAEPAAAAAACAxRHwAAAAAAAAWFyTBjxJSUn6xz/+obFjx6pr165q06aNAgMDFRMToxtvvFFr1qypV3/Lly/XlClTHH117dpVU6ZM0fLly11ad1FRkZ566inFx8crJCREAQEBiouL09133+04RhIAgMaKioqSYRgyDIMj0gGYIj093fE6xBHpAGBtNsMwjKbo+KKLLtJ///vfOtvNnDlT//nPf+Tj41NjG7vdrptvvlnz58+vsc3vfvc7vfbaa/LwaFxmtXfvXl1++eXas2dPtbe3a9dO77zzjiZMmNCocQAAAAAAAFylyWbwZGVlSZIiIiL05z//WR999JE2btyo9evX67nnnlOXLl0kSW+99ZZmz55da1/333+/I9wZPHiw3nvvPW3cuFHvvfeeBg8eLEmaN2+eHnjggUbVfOLECV1xxRWOcOf3v/+9vvvuO61bt06PPvqoAgMDdfz4cc2YMUNbtmxp1FgAAAAAAACu0mQzeCZMmKCZM2fqqquukqenZ5Xbc3NzNWLECKWmpkqSVq9erYsuuqhKu9TUVPXt21dlZWUaMmSIfvjhB/n5+TluLyoqUkJCgpKSkuTl5aXk5GT16tWrQTXPmTNHDz/8sCTpqaee0j333FPp9nXr1ikhIUFlZWVKSEjQqlWrGjQOAAAAAACAKzXZDJ5ly5Zp+vTp1YY7khQWFqZnn33Wcf2jjz6qtt0LL7ygsrIySdJLL71UKdyRJH9/f7300kuSpLKyMj3//PMNqre0tFQvvviiJKl37966++67q7QZPny4brrpJkmnA6nExMQGjQUAAAAAAOBKpp6idfHFFzsu79u3r8rthmFo6dKlkqS4uDgNGzas2n6GDRum2NhYSdLSpUvVkElJK1eu1LFjxyRJs2bNqnEvn4rLyT799NN6jwMAAAAAAOBqpgY8p06dclyubqZPWlqaYy+fhISEWvs6c/uBAwcadBJJxRO9ahtryJAh8vf3lyStXbu23uMAAAAAAAC4mpeZg69evdpxuXfv3lVu37Vrl+NyXFxcrX1VvD05OVnR0dH1qsXZsby8vNSrVy9t27ZNycnJ9RojMzOz1ttPnjyp3bt3q1OnTurQoYO8vEz98gAAAAAA0CKVlZUpJydHktS/f3/5+vqaXFHjmZYg2O12PfHEE47r06dPr9KmYiDStWvXWvuLjIx0XM7IyKh3PWfGCggIUHBwcJ1jbdu2TTk5OTp16pTatGnj1BgVawQAAAAAAObbuHGj4uPjzS6j0UxbovX8889r48aNkqSpU6fqvPPOq9LmxIkTjsuBgYG19hcQEOC4XFBQUO96zoxV1ziuGAsAAAAAAMCVTJnBs3r1av3lL3+RJHXs2FGvvPJKte1OnjzpuOzj41NrnxVn0RQXF9e7pjNj1TVOY8aqa2ZRRkaGhg8fLul0ghgeHu503wAAAAAAwDnZ2dkaOnSoJKlDhw4mV+MazR7w7Ny5U1OmTFFZWZl8fX314YcfqmPHjtW2rbgGrqSkpNZ+K27YfPZR6s44M1Zd4zRmrLqWmVUUHh5er/YAAAAAAKD+Wsr+t826RCstLU1jx47V0aNH5enpqffff18XXXRRje3btm3ruFzXUqjCwkLHZWeWWdU0ljNLrho7FgAAAAAAgCs1W8CTlZWlSy+9VFlZWbLZbHrjjTc0adKkWu9TcQZLXSdQVVz+1JDNjM+MVVhYqPz8fKfG6tChg9MbLAMAAAAAADSVZgl4cnNzNWbMGP3888+SpJdeekkzZ86s8359+vRxXN69e3etbSveXt2R664aq6ysTPv27WvwOAAAAAAAAK7W5AHPsWPHNG7cOO3atUuS9MQTT+hPf/qTU/eNjo5WRESEpNMbM9fmhx9+kCR16dJFUVFR9a5z5MiRjsu1jZWUlORYojVixIh6jwMAAAAAAOBqTRrwFBUV6YorrtBPP/0kSbr//vt13333OX1/m83mWMa1e/dubdiwodp2GzZscMy6mTRpkmw2W71rHTVqlIKCgiRJCxculGEY1bZbsGCB4/KUKVPqPQ4AAAAAAICrNVnAU1JSoilTpmjt2rWSpD//+c965JFH6t3PnXfeKU9PT0nS7bffXuVY8uLiYt1+++2STu98feedd1bbz+zZs2Wz2WSz2bRq1aoqt/v4+OiOO+6QJCUnJ+uZZ56p0mb9+vWaP3++JCkhIUHx8fH1fjwAAAAAAACu1mRngV177bX65ptvJEmjR4/WTTfdpB07dtTY3sfHRzExMVU+HxMTo3vuuUdPPPGEkpKSNGLECN13333q2bOn9u3bpyeffFKbN2+WJN1zzz0655xzGlzzPffco8WLFys1NVX33nuv9u7dq2uuuUZ+fn5auXKlHnvsMZWVlcnPz08vvPBCg8cBAAAAAABwJZtR01qkxnZcz2VS3bt3V3p6erW32e12/f73v9cbb7xR4/1vuukmvf766/LwqH5S0uzZs7Vw4UJJ0sqVKzVq1Khq2+3du1eXX3659uzZU+3t7dq10zvvvKMJEybU/GAaKDMz03ECWEZGRqVTxAAAAAAAgGu0xPffzXZMemN4eHho/vz5+uKLLzRp0iRFRETIx8dHERERmjRpkr788kvNmzevxnCnPnr16qXNmzfrySef1JAhQxQcHCx/f3/Fxsbqrrvu0rZt25ok3AEAAAAAAGioJpvBg/priQkiAAAAAADupiW+/7bEDB4AAAAAAADUjIAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4rzMLgAA4H4Mw1B+UZHS8/KUnndE6Xl5OlJYqNKycpWWl6vMbpeXh4e8PT3l7eWpkIAARYWGKio0RFFhYWrv72/2QwAAAABaFQIeAIAkKSv/mDampSktN09pebk6XnzS6ftmHDmqrRmZjutBfn6KCg1VdFiohkZHKyI4qClKBgAAAPArAh4AaMXK7HZt3r9f3yenKPngQZf1e6y4WFszM7U1M1NLtmxV7/DOGh0Xp8HdIuXlwepgAAAAwNUIeACgFTpaWKhVqXu0OiVV+cXFTT5ecvZBJWcfVLC/n0bFxCghNoZlXAAAAIALEfAAQCtSXFKiD5I2aXXqHtkNo9nHzy8q1pItW/XZ1m1KiDlH0+OHyM/bu9nrAAAAAFoaAh4AaCV2ZmXpjTXrlFdYaHYpshuGVqakalvmAf125HD1jYgwuyQAAADA0gh4AKCFKy4p0eLETVqVmmp2KVXkFRbq6a9XaFRsjGYwmwcAAABoMAIeAGjB3GnWTm1WpaRqO7N5AAAAgAbjKBMAaKGW79ipp79e4fbhzhlnZvMs37HT7FIAAAAAy2EGDwC0MIZh6JOfNuvzbdvNLqVBFicmqaikRFMHD5LNZjO7HAAAAMASmMEDAC2IYRh6d2OiZcOdMz7fuk3vbkyUYcJJXwAAAIAVEfAAQAvyyU+btWJXstlluMSKXcn6ZPMWs8sAAAAALIGABwBaiOU7dlp+5s7ZPt+6jT15AAAAACcQ8ABAC7AzK0uLE5PMLqNJLE5M0q6sbLPLAAAAANwaAQ8AWFxxSYneWLPO7DKa1Py1a1VcWmp2GQAAAIDbIuABAItbnLTJMkehN1ReQaE+aKEzlAAAAABXIOABAAvbmZWlVSmpZpfRLFampLJUCwAAAKgBAQ8AWFRrWJp1NpZqAQAAANUj4AEAi/qgFSzNOlteQaE+TNpkdhkAAACA2yHgAQALOlpUpNWpe8wuwxSrU1J1tKjI7DIAAAAAt0LAAwAWtDolVXbDMLsMU5Qbhn5opeEWAAAAUBMCHgCwmDK7XatSW8fGyjVZmZKiMrvd7DIAAAAAt0HAAwAWs3l/hvKLis0uw1T5RcXasj/D7DIAAAAAt0HAAwAW8/3u3WaX4Ba+351idgkAAACA2yDgAQALycrPV3L2QbPLcAu7srOVlX/M7DIAAAAAt0DAAwAWsjEt3ewS3MrGtDSzSwAAAADcAgEPAFhIWm6e2SW4lbQ8ng8AAABAIuABAMswDEPpBBqV/ELgBQAAAEgi4AEAy8gvKtKx4tZ9etbZ8ouLdbSoyOwyAAAAANMR8ACARTB7p3rpzOIBAAAACHgAwCrS846YXYJbIvgCAAAACHgAwDIIMqrH8wIAAAAQ8ACAZRwpLDS7BLfE8wIAAAAQ8ACAZZSWlZtdglsqLed5AQAAAAh4AMAiCDKqx/MCAAAAEPAAgGWU2e1ml+CWysp5XgAAAAACHgCwCC8PXrKr4+XJ8wIAAADwWzEAWIS3p6fZJbglnhcAAACAgAcALMPbiyCjOgQ8AAAAAAEPAFhGSECA2SW4JZ4XAAAAgIAHACwjKjTU7BLcEs8LAAAAQMADAJYRFRpidgluiYAHAAAAIOABAMsgyKheVBjPCwAAAEDAAwAWEezvryA/P7PLcCvBfn5q7+9vdhkAAACA6Zo04Dl8+LCWLVumOXPmaPz48QoLC5PNZpPNZtPs2bPrvH96erqjvbMfUVFRDa43KiqqyccAgIay2WzM4jlLd2bvAAAAAJIkr6bsvFOnTk3ZfbViY2ObfUwAaC7RYaHamplpdhluI5rACwAAAJDUxAFPRd26dVNcXJy++eYbp+/TpUsXbd++vc52jz/+uN59911J0qxZsxpc4xmTJk3SI488UuPtPj4+jR4DABpiaHS0lmzZanYZbuP8HtFmlwAAAAC4hSYNeObMmaP4+HjFx8erU6dOSk9PV3S087+Me3t7q1+/frW2KS8v16pVqyRJbdu21ZQpUxpTsiQpODi4znEBwAwRwUHqHd5ZydkHzS7FdH3CwxUeFGR2GQAAAIBbaNKAZ+7cuU3ZvSTp22+/VVZWliRp2rRp8mMDUgAt3Oi4OAIeSaPjWJILAAAAnGH5U7Teeustx2VXLM8CAHc3uFukgv1bd5gd7O+nwd0izS4DAAAAcBuWDnhOnDihJUuWSDp9AtZFF11kbkEA0Ay8PDw0KibG7DJMdXFsrDw9LP1fGAAAAOBSlv7t+KOPPlJRUZEk6YYbbpDNZnNJvz/88IMGDRqktm3byt/fX9HR0ZoxY4aWLFkiwzBcMgYANEZCbIw8XPSaZzWeNpsuijnH7DIAAAAAt9Jsp2g1hYrLs2bOnOmyftPS0ipdT09PV3p6uj744AONGDFCixcvVpcuXerdb2YdRxtnZ2fXu08ArVN7f38lxJyjlSmpZpfS7BJiY9Te39/sMgAAAAC3YtmAZ//+/Vq9erUkafjw4erVq1ej+/Tx8dGVV16psWPHql+/fgoKClJ+fr7Wr1+vV155RRkZGVq7dq3GjBmj9evXK6iep7dERrJfBADXmT7kPG3LPKC8wkKzS2k2oYEBunrIeWaXAQAAALgdywY8b7/9tmO5lKtm72zcuFHBwcFVPj9q1CjddtttmjZtmr755hslJydr7ty5eu6551wyLgA0hJ+Pj347crie/nqF2aU0m5tGjJCft7fZZQAAAABux7J78CxatEiS1KZNG82YMcMlfVYX7pzRtm1bffDBBwoJCZEkvf766yopKalX/xkZGbV+bNy4sTHlA2iF+kZEaFRs69hw+eLYGPWJCDe7DAAAAMAtWXIGz8aNG7V7925J0pVXXllrMONKQUFBuuaaa/Tyyy+rsLBQSUlJGj58uNP379q1axNWB6C1mjHkPG1v4Uu1QgMDND1+iNllAAAAAG7LkjN4mmpzZWf06dPHcfnAgQPNOjYAVOfMUq2WjKVZAAAAQO0sF/CUlpbq/ffflyR17NhRl112WbOO76qj2AHAlfpGRGhGC53hck38EJZmAQAAAHWwXMDzxRdfKC8vT5J03XXXycureVeZ7dq1y3E5IiKiWccGgNqM79dXEwf0N7sMl5o4cIAu69fX7DIAAAAAt2e5gKfi8qxZs2Y169jHjh1zzB7y9/fXkCEt86/lAKxr6rmDNaZPb7PLcIkxfXpr6uBBZpcBAAAAWIKlAp4jR47oiy++kCT1799fgwYNcvq+o0aNks1mk81mU3p6epXbv/rqKxUXF9d4/4KCAk2fPt0xe+imm25SmzZt6lU/ADQ1m82m64bGa+LAAWaX0ihXDhyg64bGsywWAAAAcFKTrm9as2aN9u7d67iem5vruLx3714tWLCgUvvZs2fX2t/777/vOJrc1bN3nnjiCV1//fWaOnWqRo4cqZ49eyowMFDHjh3TunXr9Oqrr2r//v2SpNjYWD300EMuHR8AXMVms+mqcwfL38dHixOTzC6n3mbED9F4lmUBAAAA9dKkAc+8efO0cOHCam9bu3at1q5dW+lzdQU8Z5ZneXp66vrrr3dJjRUdOXJE8+bN07x582psk5CQoHfeeUchISEuHx8AXGl8v77qHhKi+WvWWuII9dDAAN00YgQbKgMAAAAN0Lw7FDfCnj179OOPP0qSxowZo86dO7u0/2eeeUbfffed1q9fr5SUFOXm5io/P1/+/v6KiIjQ+eefr2uvvVZjx45lyQAAy+gTEa5HpkzS4sQkrUpJNbucGl0cG6Pp8UM4Ch0AAABoIJthGIbZReC0zMxMRUZGSpIyMjLUtWtXkysC0JLszMrSG2vWudVsHmbtAAAAwAwt8f23pTZZBgA0XN+ICD0yZZJGx8XKw+SZiJ42m0bHxeqRyZMIdwAAAAAXsMwSLQBA4/l5e2vmBcM0ceAArU5J1arUVOUX1XyCoKsF+/vp4thYXRRzjtr7+zfbuAAAAEBLR8ADAK1Qe39/TR48SBMGDtDm/Rn6fvduJWcfbLLx+oSHa3RcrAZ1i5SXB5NHAQAAAFcj4AGAVszLw0PxUd0VH9VdWfnHtDEtTWl5eUrPzdOx4obP7An281P3sFBFh4ZqaHS0IoKDXFg1AAAAgLMR8AAAJEkRwUGaPHiQ4/rRoiKl5+YpPe/0x5HCQpWWl6u0vFxl5XZ5eXrI29NT3p6eCgkIUFRo6OmPsFCWXwEAAADNjIAHAFCt9v7+at/NX4O7RZpdCgAAAIA6sBECAAAAAACAxRHwAAAAAAAAWBwBDwAAAAAAgMUR8AAAAAAAAFgcAQ8AAAAAAIDFEfAAAAAAAABYHAEPAAAAAACAxRHwAAAAAAAAWBwBDwAAAAAAgMUR8AAAAAAAAFgcAQ8AAAAAAIDFEfAAAAAAAABYHAEPAAAAAACAxRHwAAAAAAAAWBwBDwAAAAAAgMUR8AAAAAAAAFgcAQ8AAAAAAIDFEfAAAAAAAABYHAEPAAAAAACAxRHwAAAAAAAAWBwBDwAAAAAAgMUR8AAAAAAAAFgcAQ8AAAAAAIDFEfAAAAAAAABYHAEPAAAAAACAxRHwAAAAAAAAWBwBDwAAAAAAgMUR8AAAAAAAAFgcAQ8AAAAAAIDFEfAAAAAAAABYHAEPAAAAAACAxRHwAAAAAAAAWBwBDwAAAAAAgMUR8AAAAAAAAFgcAQ8AAAAAAIDFEfAAAAAAAABYHAEPAAAAAACAxRHwAAAAAAAAWBwBDwAAAAAAgMV5mV0AYDbDMJRfVKT0vDyl5x1Rel6ejhQWqrSsXKXl5Sqz2+Xl4SFvT095e3kqJCBAUaGhigoNUVRYmNr7+5v9EAAAAAAArRwBD1qlrPxj2piWprTcPKXl5ep48Umn75tx5Ki2ZmQ6rgf5+SkqNFTRYaEaGh2tiOCgpigZAAAAAIAaEfCg1Siz27V5/359n5yi5IMHXdbvseJibc3M1NbMTC3ZslW9wztrdFycBneLlJcHqyABAAAAAE2PgAct3tHCQq1K3aPVKanKLy5u8vGSsw8qOfuggv39NComRgmxMSzjAgAAAAA0KQIetFjFJSX6IGmTVqfukd0wmn38/KJiLdmyVZ9t3aaEmHM0PX6I/Ly9m70OAAAAAEDLR8CDFmlnVpbeWLNOeYWFZpciu2FoZUqqtmUe0G9HDlffiAizSwIAAAAAtDAEPGhRiktKtDhxk1alpppdShV5hYV6+usVGhUboxnM5gEAAAAAuBABD1oMd5q1U5tVKanazmweAAAAAIALccQPWoTlO3bq6a9XuH24c8aZ2TzLd+w0uxQAAAAAQAvADB5YmmEY+uSnzfp823azS2mQxYlJKiop0dTBg2Sz2cwuBwAAAABgUczggWUZhqF3NyZaNtw54/Ot2/TuxkQZJpz0BQAAAABoGQh4YFmf/LRZK3Ylm12GS6zYlaxPNm8xuwwAAAAAgEUR8MCSlu/YafmZO2f7fOs29uQBAAAAADQIAQ8sZ2dWlhYnJpldRpNYnJikXVnZZpcBAAAAALAYAh5YSnFJid5Ys87sMprU/LVrVVxaanYZAAAAAAALIeCBpSxO2mSZo9AbKq+gUB+00BlKAAAAAICmQcADy9iZlaVVKalml9EsVqakslQLAAAAAOA0Ah5YQmtYmnU2lmoBAAAAAJxFwANL+KAVLM06W15BoT5M2mR2GQAAAAAACyDggds7WlSk1al7zC7DFKtTUnW0qMjsMgAAAAAAbo6AB25vdUqq7IZhdhmmKDcM/dBKwy0AAAAAgPMIeODWyux2rUptHRsr12RlSorK7HazywAAAAAAuDECHri1zfszlF9UbHYZpsovKtaW/RlmlwEAAAAAcGMEPHBr3+/ebXYJbuH73SlmlwAAAAAAcGMEPHBbWfn5Ss4+aHYZbmFXdray8o+ZXQYAAAAAwE01acBz+PBhLVu2THPmzNH48eMVFhYmm80mm82m2bNnO9XHggULHPep62PBggUuqTs3N1dz5szRgAED1K5dO7Vr104DBgzQnDlzlJeX55IxULeNaelml+BWNqalmV0CAAAAAMBNeTVl5506dWrK7pvEjz/+qMmTJ+vgwcozR7Zv367t27dr3rx5WrJkiYYOHWpSha1HWi5hWkVphIsAAAAAgBo0acBTUbdu3RQXF6dvvvmmwX18/fXXioiIqPH2rl27NrhvScrIyNDEiROVk5MjLy8v/d///Z8mTJggSVq2bJmee+45ZWdna+LEidq0aVOjx0PNDMNQOoFGJb8QeAEAAAAAatCkAc+cOXMUHx+v+Ph4derUSenp6YqOjm5wfzExMYqKinJdgWe5//77lZOTI0l69913dfXVVztuu/DCC3XeeedpxowZOnz4sB544AGXLQlDVflFRTpW3LpPzzpbfnGxjhYVqb2/v9mlAAAAAADcTJPuwTN37lxNmDDBEku1Dh48qHfeeUeSNG7cuErhzhnTp0/XuHHjJEmLFi2qsowLrsPsneqlM4sHAAAAAFANTtH61WeffSa73S5JuvHGG2tsd2ZzaLvdrs8++6w5SmuV0vOOmF2CWyL4AgAAAABUh4DnV2vWrHFcTkhIqLFdxdvWrl3bpDW1ZgQZ1eN5AQAAAABUx1IBz4033qiIiAj5+PgoLCxMw4YN0wMPPKADBw40uu9du3ZJkoKCgtS5c+ca24WHh6tdu3aSpOTk5EaPi+odKSw0uwS3xPMCAAAAAKhOs52i5QqrVq1yXM7Ly1NeXp5+/PFHPfvss3rhhRd0yy23NLjvzMxMSc6dxBUZGamdO3cqIyOjQWPUJDs7u179tWSlZeVml+CWSst5XgAAAAAAVVki4OnRo4emTp2qCy64QJGRkZKkn3/+WR9//LE++ugjnTx5UrfeeqtsNptuvvnmBo1x4sQJSVJgYGCdbQMCAiRJBQUF9RrjTO2oG0FG9XheAAAAAADVcfuAZ8qUKZo1a5ZsNlulz8fHx2vGjBlatmyZpk6dqtLSUt1111268sora11iVZOTJ09Kknx8fOps26ZNG0lSMcd4N5myXze8RmVl5TwvAAAAAICq3H4PnqCgoCrhTkUTJkzQnDlzJElFRUWaP39+g8bx9fWVJJWUlNTZ9tSpU5IkPz+/eo2RkZFR68fGjRvrX3gL5eXh9t+apvDy5HkBAAAAAFTVIt4t3nzzzY4QaPXq1Q3qo23btpKcW3ZV+OtGt84s56qoa9eutX6Eh4fXv/AWytvT0+wS3BLPCwAAAACgOi0i4OnYsaNCQ0MlqcEnap3ZXLmujZAlOTZXZk+dpuPtRZBRHQIeAAAAAEB1WkTAI6nWZVzO6NOnjyTp2LFjOnjwYI3tsrOzdfz4cUlS7969GzUmahby60bWqIznBQAAAABQnRYR8OTk5Cg3N1eSFBER0aA+Ro4c6bhc2zKvireNGDGiQWOhblG/zshCZTwvAAAAAIDqtIiA5/XXX5dhGJKkhISEBvVx5ZVXyuPXjX3ffPPNGtstWLBAkuTh4aErr7yyQWOhblGhIWaX4JYIeAAAAAAA1XHrgCc9PV2bN2+utc2yZcv0j3/8Q9LpU61uvPHGatuNGjVKNptNNptN6enpVW7v3Lmzrr/+eknS119/rY8++qhKmw8//FBff/21JOmGG25o0HHscA5BRvWiwnheAAAAAABVeTVl52vWrNHevXsd188so5KkvXv3OmbDnDF79uxK19PT03XxxRfrggsu0MSJEzVw4EB17NhRkvTzzz/ro48+0kcffeSYvfPMM8+oS5cuDa730Ucf1VdffaWcnBxde+21SkpK0oQJEySdDpKeffZZSVKHDh30yCOPNHgc1C3Y319Bfn46VlxsdiluI9jPT+39/c0uAwAAAADghpo04Jk3b54WLlxY7W1r167V2rVrK33u7IDnjPXr12v9+vU1juPv76/nn39eN998c4NrlU6fivX5559r8uTJOnjwoJ588kk9+eSTldp07txZS5YscZy6haZhs9kUFRqqrU6catZadGf2DgAAAACgBk0a8DTWeeedp7ffflvr169XUlKSsrOzlZubq7KyMrVv3159+/bVJZdcot/97neOmT2Ndf7552v79u365z//qSVLljiWc0VHR2vSpEm68847HUeyo2lFhxHwVBTN9x0AAAAAoAY248z6JpguMzNTkZGRkqSMjIxWP0soK/+Y/vbpErPLcBuPT52s8KAgs8sAAAAAAMtrie+/3XqTZbRuEcFB6h3ORtaS1Cc8nHAHAAAAAFAjAh64tdFxcWaX4BZGx8WaXQIAAAAAwI0R8MCtDe4WqWB/P7PLMFWwv58Gd4s0uwwAAAAAgBsj4IFb8/Lw0KiYGLPLMNXFsbHy9OBHFQAAAABQM941wu0lxMbIw2YzuwxTeNpsuijmHLPLAAAAAAC4OQIeuL32/v5KaKUhR0JsjNr7+5tdBgAAAADAzRHwwBKmDzlPoQEBZpfRrEIDA3T1kPPMLgMAAAAAYAEEPLAEPx8f/XbkcLPLaFY3jRghP29vs8sAAAAAAFgAAQ8so29EhEbFto4Nly+OjVGfiHCzywAAAAAAWAQBDyxlRitYqhUaGKDp8UPMLgMAAAAAYCEEPLCU1rBUi6VZAAAAAID6IuCB5fSNiNCMFjrD5Zr4ISzNAgAAAADUGwEPLGl8v76aOKC/2WW41MSBA3RZv75mlwEAAAAAsCACHljW1HMHa0yf3maX4RJj+vTW1MGDzC4DAAAAAGBRXmYXADSUzWbTdUPj5evtrc+3bjO7nAa7cuAATRk8SDabzexSAAAAAAAWRcADS7PZbLrq3MHy9/HR4sQks8uptxnxQzSeZVkAAAAAgEYi4EGLML5fX3UPCdH8NWuVV1hodjl1Cg0M0E0jRrChMgAAAADAJdiDBy1Gn4hwPTJlkkbFxphdSq0ujo3RI5MnEe4AAAAAAFyGGTxoUfy8vTV7+AWKj+quN9asc6vZPMzaAQAAAAA0FWbwoEXqGxGhR6ZM0ui4WHmYvHmxp82m0XGxzNoBAAAAADQZZvCgxfLz9tbMC4Zp4sABWp2SqlWpqcovKm628YP9/XRxbKwuijlH7f39m21cAAAAAEDrQ8CDFq+9v78mDx6kCQMHaPP+DH2/e7eSsw822Xh9wsM1Oi5Wg7pFysuDSXIAAAAAgKZHwINWw8vDQ/FR3RUf1V1Z+ce0MS1NaXl5Ss/N07Hihs/sCfbzU/ewUEWHhmpodLQigoNcWDUAAAAAAHUj4EGrFBEcpMmDBzmuHy0qUnpuntLzTn8cKSxUaXm5SsvLVVZul5enh7w9PeXt6amQgABFhYae/ggLZfkVAAAAAMB0BDyATi/jat/NX4O7RZpdCgAAAAAA9cYGIQAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcQQ8AAAAAAAAFkfAAwAAAAAAYHEEPAAAAAAAABZHwAMAAAAAAGBxBDwAAAAAAAAWR8ADAAAAAABgcU0a8Bw+fFjLli3TnDlzNH78eIWFhclms8lms2n27NlO9VFUVKRPPvlEf/jDHxQfH6/27dvL29tboaGhuuCCC/TQQw/p4MGDLqk3KirKUV9tH1FRUS4ZDwAAAAAAwBW8mrLzTp06Ner+27Zt04gRI1RQUFDltiNHjmjDhg3asGGDnn/+eb3++uuaMWNGo8YDAAAAAACwoiYNeCrq1q2b4uLi9M033zh9n+PHjzvCnREjRmjChAkaMmSIQkNDlZOTo08++UT/+c9/dPz4cV1//fVq166dxo8f3+haJ02apEceeaTG2318fBo9BgAAAAAAgKs0acAzZ84cxcfHKz4+Xp06dVJ6erqio6Odvr+Hh4emT5+uBx98UH369Kly+9ixYzV+/HhNmTJF5eXluv3227Vnzx7ZbLZG1R0cHKx+/fo1qg8AAAAAQMMY9jKVHN+rU0d26OSR7Tp1ZIfKig7KKD8lw14im4ePbJ5t5OXfWW1C+sk3pL/ahPSTT7tesnk02zwGwK006Xf+3LlzG3X/4cOHa/jw4bW2mTRpkqZOnaqPP/5Y+/bt0+bNm3Xuuec2alwAAAAAQPMyDEMnc5KUv+dtFWaukFFeXOd9yoqydDL3Jx379brN008BXccoOOYG+Yad1+g//gNW0iJO0br44osdl/ft22diJQAAAACA+rCXFip/zzvav3y8Mr+droJfPnMq3KmOUV6sgl8+U+aKq7V/+eU6tudd2UsLXVwx4J5aRMBz6tQpx2VPT08TKwEAAAAAOOvE/uVK/zxBOYkPqCQ/xaV9l+Tv1uHE+5X+eYJO7F/u0r4Bd9QiAp7Vq1c7Lvfu3bvR/f3www8aNGiQ2rZtK39/f0VHR2vGjBlasmSJDMNodP8AAAAA0JqVncxT9prbdHDNH1V+Mq9Jxyo/maeDa/6o7DW3q/zkkSYdCzCT5Xef2rp1q7744gtJUv/+/V0S8KSlpVW6np6ervT0dH3wwQcaMWKEFi9erC5dutS738zMzFpvz87OrnefAAAAAGAlBRnf6PDGv6n8VNMGO1XG3b9MxYfWq+PQxxQYObZZxwaag6UDnlOnTul3v/udysvLJUmPPvpoo/rz8fHRlVdeqbFjx6pfv34KCgpSfn6+1q9fr1deeUUZGRlau3atxowZo/Xr1ysoKKhe/UdGRjaqPgAAAACwsvyUN5Wz6R+mjV9+Kk/Z/71FHc57UMGxs02rA2gKlg54brvtNiUlJUmSZs2apYkTJzaqv40bNyo4OLjK50eNGqXbbrtN06ZN0zfffKPk5GTNnTtXzz33XKPGAwAAAIDW4sjOl5W39Wmzy5Ak5WyaK3tZkUL6/tHsUgCXsWzA8/jjj2vevHmSpPj4eP373/9udJ/VhTtntG3bVh988IF69OihI0eO6PXXX9cTTzwhHx8fp/vPyMio9fbs7GwNHTrU6f4AAAAAwAryU950m3DnjLytT8vDy5+ZPGgxLBnwvPbaa/rb3/4mSYqLi9OXX36pgICAJh83KChI11xzjV5++WUVFhYqKSlJw4cPd/r+Xbt2bcLqAAAAAMD9FGR8Y+qyrNrkbJorL/8I9uRBi2C5U7Tee+89/fGPp6fRde/eXStWrFBYWFizjd+nTx/H5QMHDjTbuAAAAABgNWUn83R449/MLqNWhxP/xulaaBEsFfB89tlnmjlzpux2u8LDw/Xdd981+6wYm83WrOMBAAAAgFXlJD3Y7Kdl1Vf5yTwdTnrQ7DKARrNMwPPdd99p+vTpKisrU2hoqFasWKGePXs2ex27du1yXI6IiGj28QEAAADACk7s/1IF+78wuwynFOxfphP7l5tdBtAolgh41q1bp0mTJunUqVMKCgrS119/rb59+zZ7HceOHdP7778vSfL399eQIUOavQYAAAAAcHf20kLlJM0xu4x6yUn6u+ylhWaXATSY2wc8W7Zs0RVXXKHCwkIFBAToiy++0HnnnVfvfkaNGiWbzSabzab09PQqt3/11VcqLi6u8f4FBQWaPn268vJOTy+86aab1KZNm3rXAQAAAAAt3Yn0pSo/6d5Ls85WfjJPJ35ZanYZQIM16Slaa9as0d69ex3Xc3NzHZf37t2rBQsWVGo/e/bsStf37duncePGKT8/X5L0yCOPKCgoSDt27KhxzI4dO6pjx471rvWJJ57Q9ddfr6lTp2rkyJHq2bOnAgMDdezYMa1bt06vvvqq9u/fL0mKjY3VQw89VO8xAAAAAKClMwxD+XsWmV1Gg+SnLlK7ntey9yosqUkDnnnz5mnhwoXV3rZ27VqtXbu20ufODnj++9//6vDhw47rd911V51jPvjggw0OX44cOaJ58+Zp3rx5NbZJSEjQO++8o5CQkAaNAQAAAAAt2cmcJJXk7za7jAYpyd+tk7mb5NeB7ThgPU0a8FjJM888o++++07r169XSkqKcnNzlZ+fL39/f0VEROj888/Xtddeq7Fjx5LmAgAAAEAN8ve8bXYJjZKfuoiAB5ZkMwzDMLsInJaZmanIyEhJUkZGRrMfAQ8AAAAAjWHYy7TvwwEyymve39Td2Tz91PPqbbJ5MB+iJWuJ77/dfpNlAAAAAIA1lBzfa+lwR5KM8mKVHN9ndhlAvRHwAAAAAABc4tSRmg/EsZKW8jjQuhDwAAAAAABc4uSR7WaX4BIt5XGgdSHgAQAAAAC4REuZ+dJSHgdaFwIeAAAAAIBLlBUdNLsElygryja7BKDeCHgAAAAAAC5hlJ8yuwSXMOwt43GgdSHgAQAAAAC4hGEvMbsElzDKW8bjQOtCwAMAAAAAcAmbh4/ZJbiEzbNlPA60Ll5mFwAAQFMxDEP5RUVKz8tTet4Rpefl6UhhoUrLylVaXq4yu11eHh7y9vSUt5enQgICFBUaqqjQEEWFham9v7/ZDwEAAEuxebYxuwSXsHm0jMeB1oWABwDQomTlH9PGtDSl5eYpLS9Xx4tPOn3fjCNHtTUj03E9yM9PUaGhig4L1dDoaEUEBzVFyQAAtBhe/p1VVpRldhmN5uUfbnYJQL0R8AAALK/Mbtfm/fv1fXKKkg+67vSOY8XF2pqZqa2ZmVqyZat6h3fW6Lg4De4WKS8PVjkDAHC2NiH9dDL3J7PLaLQ2If3MLgGoNwIeAIBlHS0s1KrUPVqdkqr84uImHy85+6CSsw8q2N9Po2JilBAbwzIuAAAq8A3pr2NmF+ECviH9zS4BqDcCHgCA5RSXlOiDpE1anbpHdsNo9vHzi4q1ZMtWfbZ1mxJiztH0+CHy8/Zu9joAAHA3LWXmS0t5HGhdCHgAAJayMytLb6xZp7zCQrNLkd0wtDIlVdsyD+i3I4erb0SE2SUBAGAqn3a9ZPP0k1He9DNrm4rN008+7XqaXQZQb2wgAACwhOKSEi1Yu15Pf73CLcKdivIKC/X01yu0YN16FZeWml0OAACmsXl4KaDrGLPLaJSArmNk82AuBKyH71oAgNtzp1k7tVmVkqrtzOYBALRywef8RgW/fGZ2GQ0WHHOD2SUADcIMHgCAW1u+Y6dbztqpyZnZPMt37DS7FAAATOHbYYh8guPMLqNBfIJ7yzfsPLPLABqEgAcA4JYMw9DHm37S4sQks0tpkMWJSfr4p80yTNgEGgAAM9lsNgWfY81ZMMExv5HNZjO7DKBBCHgAAG7HMAy9uzFRn2/bbnYpjfL51m16d2MiIQ8AoNVpGzVJnr6hZpdRL56+oWrbfZLZZQANRsADAHA7n/y0WSt2JZtdhkus2JWsTzZvMbsMAACalYd3gDoMedjsMuqlY/wj8vAOMLsMoMEIeAAAbmX5jp2Wn7lzts+3bmNPHgBAq9O223gFdrvC7DKcEthtggIjLzO7DKBRCHgAAG5jZ1aWZffcqcvixCTtyso2uwwAAJpVhyFz5dnGvZdqefqGquOQuWaXATQaAQ8AwC0Ul5TojTXrzC6jSc1fu1bFpaVmlwEAQLPx8g1Vx6GPmV1GrTrGPyZP3xCzywAajYAHAOAWFidtssxR6A2VV1CoD1roDCUAAGoSGDlWHc6bY3YZ1epw3oMKjBxrdhmASxDwAABMtzMrS6tSUs0uo1msTEllqRYAoNUJjr1RoQPvMbuMSkIH3qvg2NlmlwG4DAEPAMBUrWFp1tlYqgUAaI1C+v5RHc570OwyJEkdzntIIX3/YHYZgEsR8AAATPVBK1iadba8gkJ9mLTJ7DIAAGh2wbGzFX7ha6ZtvOzpG6rwC19TcOwsU8YHmhIBDwDANEeLirQ6dY/ZZZhidUqqjhYVmV0GAADNLjByrLpf8Y0Cu01o3nG7T1T3y79hzx20WAQ8AADTrE5Jld0wzC7DFOWGoR9aabgFAICnb4jCR76kziNflqdv087mOT1r5xWFj3iR07LQonmZXQAAoHUqs9u1KrV1bKxck5UpKbpiQH95efD3FgBA69S223gFhF+kE+lLlb9nkUryd7usb5/gOAXH3KC23SfJwzvAZf0C7oqABwBgis37M5RfVGx2GabKLyrWlv0ZGhLV3exSAAAwjYd3gILOuU7tel2rk7mblJ+6SIWZK2SU1//3BJunnwK7jlVQzA3yDTtXNputCSoG3BMBDwDAFN/vdt1f6Kzs+90pBDwAAEiy2Wzy6zBEfh2GyLCXqeT4Pp06skMnj2zXqSM7VFaULcN+SkZ5iWyePrJ5tJGXf7jahPSTb0h/tQnpJ592PWXz4G0uWie+8wEAzS4rP1/J2QfNLsMt7MrOVlb+MUUEB5ldCgAAbsPm4aU2wbFqExyrdj2uMrscwBJY9A8AaHYb09LNLsGtbExLM7sEAAAAWBwBDwCg2aXl5pldgltJy+P5AAAAQOMQ8AAAmpVhGEon0KjkFwIvAAAANBIBDwCgWeUXFelYces+Pets+cXFOlpUZHYZAAAAsDACHgBAs2L2TvXSmcUDAACARiDgAQA0q/S8I2aX4JYIvgAAANAYBDwAgGZFkFE9nhcAAAA0BgEPAKBZHSksNLsEt8TzAgAAgMYg4AEANKvSsnKzS3BLpeU8LwAAAGg4Ah4AQLMiyKgezwsAAAAag4AHANCsyux2s0twS2XlPC8AAABoOAIeAECz8vLgv57qeHnyvAAAAKDh+G0SANCsvD09zS7BLfG8AAAAoDEIeAAAzcrbiyCjOgQ8AAAAaAwCHgBAswoJCDC7BLfE8wIAAIDGIOABADSrqNBQs0twSzwvAAAAaAwCHgBAs4oKDTG7BLdEwAMAAIDGIOABADQrgozqRYXxvAAAAKDhCHgAAM0q2N9fQX5+ZpfhVoL9/NTe39/sMgAAAGBhBDwAgGZls9mYxXOW7szeAQAAQCMR8AAAml00gUYl0QReAAAAaCQCHgBAsxsaHW12CW7l/B48HwAAAGgcL7MLAAC0PhHBQeod3lnJ2QfNLsV0fcLDFR4UZHYZzcKwl6nk+F6dOrJDJ49s16kjO1RWdFBG+SkZ9hLZPHxk82wjL//OahPST74h/dUmpJ982vWSzYNfWQAAAGrDb0sAAFOMjosj4JE0Oi7W7BKalGEYOpmTpPw9b6swc4WM8uI671NWlKWTuT/p2K/XbZ5+Cug6RsExN8g37DzZbLamLRoAAMCCCHgAAKYY3C1Swf5+yi+q+w1/SxXs76fB3SLNLqNJ2EsLdTx9iY7tWaSS/JRG9WWUF6vgl89U8Mtn8gmOU/A5N6ht1CR5eAe4qFoAAADrYw8eAIApvDw8NComxuwyTHVxbKw8PVref8Un9i9X+ucJykl8oNHhztlK8nfrcOL9Sv88QSf2L3dp3wAAAFbW8n6rBABYRkJsjDxa6XIbT5tNF8WcY3YZLlV2Mk/Za27TwTV/VPnJvCYdq/xkng6u+aOy19yu8pNHmnQsAAAAKyDgAQCYpr2/vxJaWMjhrITYGLX39ze7DJcpyPhG+78Yp4L9XzTvuPuX6Zcvxqog45tmHRcAAMDdEPAAAEw1fch5Cg1oXXuphAYG6Ooh55ldhsvkp7yp7P/eovJTTTtrpyblp/KU/d9blJ+ywJTxAQAA3AEBDwDAVH4+PvrtyOFml9GsbhoxQn7e3maX4RJHdr6snE3/MLsMSVLOprk6svNls8sAAAAwBQEPAMB0fSMiNCq2dWy4fHFsjPpEhJtdhkvkp7ypvK1Pm11GJXlbn2YmDwAAaJUIeAAAbmFGK1iqFRoYoOnxQ8wuwyUKMr5xm5k7Z8vZNJc9eQAAQKvjZXYBAABI/1uq9fTXK8wupck0dmlWWXmp9qRt1779O5WWsVtH8g+prLxUXp7eCgnupOjIOPXs1lfnRPeXl2fTLQErO5mnwxv/1uD7l9uljAJPHSjwVFahp46d8lC5IXnapKA2dkUElKtLYLkiA8vl2cA/RR1O/Jv8OgyRp29Ig+sEAACwEgIeAIDb6BsRoRnxQ7Q4McnsUlzumvghDV6adST/kFas+VjfrftE+cdza2z338TTJ1gFtwvTpSOm6tIRVykkuFODxqxNTtKDDdpQ+dgpmxIP+SjxkI8KSmtObrbknP430Nuu+E4liu9UoqA2Rr3GKj+Zp8NJDyp85Ev1rhMAAMCKbIZh1O83JjSZzMxMRUZGSpIyMjLUtWtXkysCAHN8vOknfb5tu9lluMzEgQN01bmD632/8vIyLV3xpj766nWVlZXW+/5eXt6adtnNmjTmRnl6uuZvOif2f6mDa/5Ur/uUG9IPB9poZUYblRu2eo/paTN0ceQpXdTllDzreffOI19W227j6z0mAABo2Vri+2/24AEAuJ2p5w7WmD69zS7DJcb06a2pgwfV+37Zh3/R/c/M1PvL/t2gcEeSyspK9f6yf+v+Z2Yq+/AvDeqjIntpoXKS5tTrPrnFHnp1W4C+3e/boHBHksoNm77d76tXtwUot7h+v7rkJP1d9tLCBo0LAABgJQQ8AAC3Y7PZdN3QeE0cOMDsUhrlyoEDdN3QeNls9Qs20jNT9PfnZuvnjF0uqePnjF2a8/yNSs9MaVQ/J9KXqvyk80uzsgs99Pr2AGUVumb2UFahl17fEaDsQud/fSk/macTvyx1yfgAAADurEkDnsOHD2vZsmWaM2eOxo8fr7CwMNlsNtlsNs2ePbve/S1fvlxTpkxR165d1aZNG3Xt2lVTpkzR8uXLXVp3UVGRnnrqKcXHxyskJEQBAQGKi4vT3XffrV9+afxfQAEAdbPZbLrq3MGaYdFTp2bED9HUcwfXO9zJPvyLHvnXrTpecLTWdqUl5Tp+5KSOHCrS8SMnVVpSXmv7YyeO6JF/3drgmTyGYSh/zyKn2+cWe+jNnQEqLKv9V436Po7C0tP91mcmT37qIrEiHQAAtHRNuslyp06u2djRbrfr5ptv1vz58yt9/sCBAzpw4ICWLFmi3/3ud3rttdfk4dG4zGrv3r26/PLLtWfPnkqfT0lJUUpKiubNm6d33nlHEyZMaNQ4AADnjO/XV91DQjR/zVrlFbr/UpvQwADdNGJEgzZULisv1T/f/GuN4Y5hGMo5UKi9O3KV9fMxVcwsbDapS48g9ewXpg5dAqoNlo4XHNWLC/6qR+5+q9578pzMSVJJ/m6n2pbbpcWpfjWGO419HIVlHvog1U+3DCh0ak+ekvzdOpm7SX4drBkWAgAAOKPZlmh169ZNY8eObdB977//fke4M3jwYL333nvauHGj3nvvPQ0efHrTynnz5umBBx5oVI0nTpzQFVdc4Qh3fv/73+u7777TunXr9OijjyowMFDHjx/XjBkztGXLlkaNBQBwXp+IcD0yZZJGxcaYXUqtLo6N0SOTJzX4tKzPViyocVnW0ZwiffN+qlYv3acD+yqHIpJkGFLmvmNavXSfvnk/VUdziqrtZ9/+XVr67YJ615a/522n2/6Q1abGZVmuehwHCr303wNtnK8/1fnZRwAAAFbUpKdoPfjgg4qPj1d8fLw6deqk9PR0RUdHS5JmzZqlBQsW1NlHamqq+vbtq7KyMg0ZMkQ//PCD/Pz8HLcXFRUpISFBSUlJ8vLyUnJysnr16tWgeufMmaOHH35YkvTUU0/pnnvuqXT7unXrlJCQoLKyMiUkJGjVqlUNGqcmLXEXbwBwtZ1ZWXpjzTq3ms3TmFk7ZxzJP6TbHppQ7YbKhzJOaO2X6Sovszs+10nSWElBko5J+kbSoQr38fTy0IjLo9Qpsm2V/ry8vPWvh5Y5fYS6YS/Tvg8HyCgvrrPtsVM2PftT22o3VHb14/C0Gbr73BNOHaFu8/RTz6u3yebRpJOXAQCARbTE999NOoNn7ty5mjBhQqOWar3wwgsqKyuTJL300kuVwh1J8vf310svvSRJKisr0/PPP9+gcUpLS/Xiiy9Kknr37q277767Spvhw4frpptukiStXr1aiYmJDRoLANBwfSMi9MiUSRodFyuPeu5v42qeNptGx8U2atbOGSvWfFxtuHM0p6hSKDJY0mJJ+yW9JemlX//dL+n9X2+XpPIyu9Z+mV7tDJiyslJ9u/Zjp2srOb7XqXBHkhIP+VQb7jTF4yg3bEo85ONUXUZ5sUqO73OqLQAAgBW59SlahmFo6dLTJ1/ExcVp2LBh1bYbNmyYYmNjJUlLly5t0EaKK1eu1LFjxySdnl1U014+FTeH/vTTT+s9DgCg8fy8vTXzgmF6dvo0TR40UMH+fnXfyYWC/f00ZfAgPTN9mmZeMEx+3t6N6q+svFTfrfukyucNw9DGbzMcochkSeskTZd0dqzhI2nGr7dP+vVz5WV2bfw2o9r/F79d+4nKyp07fv3UkR1OtSu3q9rApSkfR+IhH5Xbq3y6Ws4+DgAAACty64AnLS1NWVlZkqSEhIRa2565/cCBA0pPT6/3WGvWrKnSV3WGDBkif39/SdLatWvrPQ4AwHXa+/tr8uBBeubqafrTxaPUO7xzk47XJzxct108Ss9cPU2TBg1U+1//P2isPWnblX88t8rncw4U6viRk5JOz2h5T5JvHX35qvIMmONHTionq+pytvzjudqb7lzgcfLIdqfaZRR4qqC06q8WTfk4Cko9lFHg6VR9zj4OAAAAK3Lrhei7dv1vo8m4uLha21a8PTk52bHXj6vH8vLyUq9evbRt2zYlJyfXawwAQNPw8vBQfFR3xUd1V1b+MW1MS1NaXp7Sc/N0rNi5pUXVCfbzU/ewUEWHhmpodLQigoNcWPX/7Nu/s/rP7/hf6HOf6g5FzvCVdK+ka8/0sz1XHbsEVjtuXM/BVT5/NmdnvhyoIWhp6sdxoMBTUe1qP15dYgYPAABo2dw64MnMzHRcrmvDozObI0mnN0hq6FgBAQEKDg6uc6xt27YpJydHp06dUps2zp3iUfHxVCc7O9upfgAANYsIDtLkwYMc148WFSk9N0/peac/jhQWqrS8XKXl5Sort8vL00Penp7y9vRUSECAokJDT3+Ehbpshk5d0jKqHj9eWlKuAz+fXjrcSdKUevY5VVJHSYclHfj5mEpLyuXtUzmA+Xm/c3+oKCs66FS7rMKqAU9zPI7qxq1OWRH/zwIAgJbLrQOeEydOOC4HBlb9i11FAQEBjssFBQUNHquucaoby9mAp2IIBQBoHu39/dW+m78Gd3Pf1+Aj+YeqfK64oNRxhPhYVd2rpi4+ksZJWqTTR48XF5TKO6RyEFLduNUxyk851e7YqarLs5rjcVQ3bnUMu3OPAwAAwIrceg+ekydPOi77+NT+K2HFkKW4AdPxz4xV1ziuGAsAgIqq2+y4rPR/Owc3dGFYuxr6q23c6hj2EqfalVdzxkFzPI7qxq2OUe7c4wAAALAit57B4+v7v1X6JSW1/1J26tT//ip39lHq9RmrrnEaM1ZdS8eys7M1dOhQp/sDALQMXp5VT+Hy8v7f32CONbDf4zX0V9u41bF5ODfvxrOaU+ub43FUN251bJ71nT8EAABgHW4d8LRt29Zxua5lV4WF/ztZw5llVjWN5czyroaOVdc+QgCA1ikkuFOVz/kFestmO70s6RtJJarf8qYSSV//etnmcbo/Z8atjs3TuaXIQW2qzq5pjsdR3bjVsXk49zgAAACsyK2XaFUMROraoLji7JiG7HVzZqzCwkLl5+c7NVaHDh2c3n8HAICaREdWPb3R28dTXXqcXtR0SNKn9ezzE53emFiSukQHVdmYWJJ6dOvtVF9e/s4dPx8RUPUkq+Z4HNWNWx0v//B6jg4AAGAdbh3w9OnTx3F59+6qJ4xUVPH23r2d+4W1IWOVlZVp3759DR4HAICz9ezWt/rP9wtzXH5S0slqW1VVLOmpiv30D6u2XU3jnq1NSD+n2nUJrD5oaerHUdO4Z3P2cQAAAFiRWwc80dHRioiIkCStXr261rY//PCDJKlLly6Kioqq91gjR450XK5trKSkJMcSrREjRtR7HAAAznZOdH8Ft6saXnToEqB2Iaf3iNss6RrVHY6clHTtr+0lqV2IrzpEBFRpF9wuTL2inAs8fEP6O9UuMrBcgd5Vl0s15eMI9LYr0smAx9nHAQAAYEVuHfDYbDZNmjRJ0ulZNRs2bKi23YYNGxyzbiZNmiSbzcndFisYNWqUgoJOTyFfuHChDKP6IzkWLFjguDxlypR6jwMAwNm8PL11yfCpVT5vs9k09NJIeXqd/u96qaThkhbr9N40FZVIev/X25f++jlPLw8NvTSy2v8XLx0x1elNlp2d+eLpIcV3qnpYQVM+jvhOJfJ08rcZZvAAAICWzK0DHkm688475el5er397bffXuVY8uLiYt1+++2SJC8vL915553V9jN79mzZbDbZbDatWrWqyu0+Pj664447JEnJycl65plnqrRZv3695s+fL0lKSEhQfHx8Qx8WAACVjBl5lby8qgYu7Tv4a8TlUY5w5MwMmG6SZkq67dd/I1V5xounl4dGXB6l9h38q/Tp5eWtS0dc5XRtPu16yebp3KmR8Z1K5Gmr+keSpngcnjaj2kCpOjZPP/m06+lUWwAAACtq0lO01qxZo7179zqu5+bmOi7v3bu30mwY6XQIc7aYmBjdc889euKJJ5SUlKQRI0bovvvuU8+ePbVv3z49+eST2rz59K+B99xzj84555wG13vPPfdo8eLFSk1N1b333qu9e/fqmmuukZ+fn1auXKnHHntMZWVl8vPz0wsvvNDgcQAAOFtIcCdNu+xmvb/s31Vu6xTZVhdP7amN32bo+JHTi5sOSVpUQ1/tQnw19NLIakMRSZo2/hanT9CSJJuHlwK6jlHBL5/V2TaojaGLI0/p2/2+VW5z9eMYHXlKQW2qn3F7toCuY2TzcOvDQwEAABrFZtS0FskFZs+erYULFzrdvqZS7Ha7fv/73+uNN96o8b433XSTXn/9dXl4VD8pqWItK1eu1KhRo6ptt3fvXl1++eXas2dPtbe3a9dO77zzjiZMmFDLI2mYzMxMxwlgGRkZHKsOAK1MeXmZ7n9mpn7O2FXt7YZhKCerUPu25+rAz8dU8b9Nm8fpU6Z69g9Th4iAGpcr9+zWR4/c/ZY8PesXdhQfTlTmt9OdexyG9Oq2AGUVVj+GKx5Hl4Ay3TKgUJ5OrsruOuZD+XUY4lxjAADQ4rXE99+W+FOWh4eH5s+fr6uuukqvv/66EhMTlZubq7CwMMXHx+uWW27R+PHjXTJWr169tHnzZv373//Whx9+qL1796qkpESRkZG6/PLL9ec//1ndu3d3yVgAAFTk6emlP9/4uP7+3GwdLzha5XabzaaOXQLVsUugSkvKVVxQqrJSu7y8PeQX6F3tEeIVBbUN0R2zH693uCNJvh2GyCc4TiX5tZ9qKUmeNmlGTLFe3x6gwrKqf3hp7OMI8LZrekyx0+GOT3Bv+Yad51xjAAAAi2rSGTyon5aYIAIA6i89M0WP/OvWakOehgpqG6IHbntV3bvENLiPY3ve1eHE+51un13ooTd3Vh/yNFSAt12/7VOozgFVT+uqScehjyqo13UuqwEAAFhfS3z/7fabLAMA0NpEdY3Vw/+3QD0i+7ikv57d+ugfd73ZqHBHktpGTZKnb6jT7cMD7Lq5f6EiAsoaNe4ZXQLKdHO/+oU7nr6hatt9kkvGBwAAcGcEPAAAuKHwjt316P97S9dMvK3a07Wc4eXlrWsm3qZH7n5L4R0bv7zYwztAHYY8XK/7hPnZdeuAQo3pdrLa07Wc4WkzNKbbSd0yoFBhfs6HO5LUMf4ReXgHNGhcAAAAK7HEHjwAALRGnp5emjrudxp1/kR9u/Zjfbv2E+Ufz63zfu3bddAlI6bq0hFT63ValjPadhuvgm5XqGD/F07fx9Mmjep6SoM7lCjxkI8SD/mooLTuvzG19bYrvlOJhnQqcfq0rIoCu01QYORl9b4fAACAFbEHjxtpiWsAAQCuU1Zeqr3pO7Rv/079vD9ZR/IPqay8VF6e3goJ7qQe3XqrZ7e+6hXVT16eDZv141QdJ/O0/4txKj+V16D7l9uljAJPHSjwVFahp46d8lC5cToICmpjV0RAuboElisysFyeDZxr7Okbqu6XfyNP35CGdQAAAFq0lvj+mxk8AABYhJent+J6DlZcz8Hm1uEbqo5DH1P2f29p0P09PaSoduWKalfu4sr+p2P8Y4Q7AACgVWEPHgAAUG+BkWPV4bw5ZpdRrQ7nPajAyLFmlwEAANCsCHgAAECDBMfeqNCB95hdRiWhA+9VcOxss8sAAABodgQ8AACgwUL6/lEdznvQ7DIkSR3Oe0ghff9gdhkAAACmIOABAACNEhw7W+EXvibPNqGmjO/pG6rwC19TcOwsU8YHAABwBwQ8AACg0QIjx6r7Fd8osNuE5h23+0R1v/wb9twBAACtHgEPAABwCU/fEIWPfEmdR74sT9+mnc1zetbOKwof8SKnZQEAAIhj0gEAgIu17TZeAeEX6UT6UuXvWaSS/N0u69snOE7BMTeobfdJ8vAOcFm/AAAAVkfAAwAAXM7DO0BB51yndr2u1cncTcpPXaTCzBUyyovr3ZfN00+BXccqKOYG+YadK5vN1gQVAwAAWBsBDwAAaDI2m01+HYbIr8MQGfYylRzfp1NHdujkke06dWSHyoqyZdhPySgvkc3TRzaPNvLyD1ebkH7yDemvNiH95NOup2we/MoCAABQG35bAgAAzcLm4aU2wbFqExyrdj2uMrscAACAFoVNlgEAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACyOgAcAAAAAAMDiCHgAAAAAAAAsjoAHAAAAAADA4gh4AAAAAAAALI6ABwAAAAAAwOIIeAAAAAAAACzOy+wCAAAAgNbIMAzlFxUpPS9P6XlHlJ6XpyOFhSotK1dpebnK7HZ5eXjI29NT3l6eCgkIUFRoqKJCQxQVFqb2/v5mPwQAgBsh4AEAAACaSVb+MW1MS1Nabp7S8nJ1vPik0/fNOHJUWzMyHdeD/PwUFRqq6LBQDY2OVkRwUFOUDACwCAIeAAAAoAmV2e3avH+/vk9OUfLBgy7r91hxsbZmZmprZqaWbNmq3uGdNTouToO7RcrLg50YAKC1IeABAAAAmsDRwkKtSt2j1Smpyi8ubvLxkrMPKjn7oIL9/TQqJkYJsTEs4wKAVoSABwAAAHCh4pISfZC0SatT98huGM0+fn5RsZZs2arPtm5TQsw5mh4/RH7e3s1eBwCgeRHwAAAAAC6yMytLb6xZp7zCQrNLkd0wtDIlVdsyD+i3I4erb0SE2SUBAJoQAQ8AAADQSMUlJVqcuEmrUlPNLqWKvMJCPf31Co2KjdEMZvMAQIvl9ruvjRo1SjabrV4fq1atqvc4Dz30UJP2DwAAgJZpZ1aWHljymVuGOxWtSknVA58u1c6sLLNLAQA0AbcPeOrLw8ND55xzjtllAAAAoBVYvmOnnv56hVssyXLGmdk8y3fsNLsUAICLuf0SrTfffFOFdfyHuWvXLs2YMUOSdMkll6hLly6NGnP79u213h4dHd2o/gEAAGBthmHok5826/Nttf/e6K4WJyapqKREUwcPks1mM7scAIALuH3A40yYsmjRIsflmTNnNnrMfv36NboPAAAAtEyGYejdjYlasSvZ7FIa5fOt23SytFTXDY0n5AGAFsDyS7TsdrveeecdSVJgYKCmTp1qckUAAABoyT75abPlw50zVuxK1iebt5hdBgDABSwf8Hz33Xc6cOCAJGnatGny9/c3uSIAAAC0VMt37LTssqyafL51G3vyAEALYPmA56233nJcdsXyLAAAAKA6O7OytDgxyewymsTixCTtyso2uwwAQCO4/R48tSkoKNCnn34qSerevbtGjRrlkn7Hjh2rLVu2KD8/X8HBwerTp48uu+wy3XLLLWrfvn2D+83MzKz19uxs/lMFAABwR8UlJXpjzTqzy2hS89eu1SOTJ8nP29vsUgAADWDpgOfjjz92nLD1m9/8xmWbw61YscJxOScnR6tXr9bq1av15JNPasGCBZo0aVKD+o2MjHRJfQAAAGhei5M2WeYo9IbKKyjUB4lJmjX8ArNLAQA0gKWXaLl6eVb//v3197//XZ9//rk2bdqkDRs2aOHChRo7dqwkKT8/X1dddZWWL1/e6LEAAABgDTuzsrQqJdXsMprFypRUlmoBgEXZDMMwzC6iITIzM9W9e3fZ7XYNGzZM69evb1R/Z5Zj1eS1117TrbfeKkmKiIjQvn375OvrW68xnFmiNXToUElSRkaGunbtWq/+AQAA4FrFJSV6YMlnLX72TkWhgQEs1QLQ4mVmZjpW2bSU99+WXaL19ttvy263S5JmzZrV6P5qC3ck6ZZbblFiYqLmz5+vrKwsffzxx7r++uvrNUZL+IYBAABoTT5oBUuzzpZXUKgPkzZp5gXDzC4FAFAPll2itWjRIklSmzZtNGPGjGYZ85ZbbnFcXr16dbOMCQAAAHMcLSrS6tQ9ZpdhitUpqTpaVGR2GQCAerBkwJOUlKRdu3ZJkiZMmNCok63qo0+fPo7LBw4caJYxAQAAYI7VKamyW3M3g0YrNwz90ErDLQCwKksGPBU3V3bF8ixnueqULgAAALi3Mrtdq1Jbx8bKNVmZkqKyX7dEAAC4P8sFPKWlpXr//fclSR06dND48eObbewzs4ak0xstAwAAoGXavD9D+UXFZpdhqvyiYm3Zn2F2GQAAJ1ku4Fm+fLlycnIkSdddd528vJpvn+jXXnvNcTkhIaHZxgUAAEDz+n73brNLcAvf704xuwQAgJMsF/BUXJ41c+ZMp+6zYMEC2Ww22Ww2PfTQQ1Vu3759u/bu3VtrH6+//rrmzZsnSercubOmTJnifNEAAACwjKz8fCVnHzS7DLewKztbWfnHzC4DAOAESx2TfvToUS1btkyS1K9fP5177rku6XfTpk363e9+p4svvljjx49X//79FRoaqrKyMu3evVvvvPOOvvnmG0mSp6enXn/9dQUEBLhkbAAAALiXjWnpZpfgVjampWny4EFmlwEAqIOlAp7Fixfr1KlTkpyfveOs8vJyffvtt/r2229rbBMaGqr58+dr4sSJLh0bAAAA7iMtN8/sEtxKWh7PBwBYgaUCnkWLFkk6PYvm+uuvd1m/l19+uebPn6/169dr8+bNOnTokPLy8mQYhkJCQjRw4EBddtllmj17ttq1a+eycQEAAOBeDMNQOoFGJb8QeAGAJdgMwzDMLgKnZWZmKjIyUpKUkZGhrl27mlwRAABA63K0sFB3ffCR2WW4nednXK32/v5mlwEALtMS339bbpNlAAAAoKkwe6d66cziAQC3R8ADAAAA/Co974jZJbglgi8AcH8EPAAAAMCvCDKqx/MCAO6PgAcAAAD41ZHCQrNLcEs8LwDg/gh4AAAAgF+VlpWbXYJbKi3neQEAd0fAAwAAAPyKIKN6PC8A4P4IeAAAAIBfldntZpfglsrKeV4AwN0R8AAAAAC/8vLg1+PqeHnyvACAu+OVGgAAAPiVt6en2SW4JZ4XAHB/BDwAAADAr7y9CDKqQ8ADAO6PgAcAAAD4VUhAgNkluCWeFwBwfwQ8AAAAwK+iQkPNLsEt8bwAgPsj4AEAAAB+FRUaYnYJbomABwDcHwEPAAAA8CuCjOpFhfG8AIC7I+ABAAAAfhXs768gPz+zy3ArwX5+au/vb3YZAIA6EPAAAAAAv7LZbMziOUt3Zu8AgCUQ8AAAAAAVRBNoVBJN4AUAlkDAAwAAAFQwNDra7BLcyvk9eD4AwAoIeAAAAIAKIoKD1Du8s9lluIU+4eEKDwoyuwwAgBMIeAAAAICzjI6LM7sEtzA6LtbsEgAATiLgAQAAAM4yuFukgv1b92lawf5+Gtwt0uwyAABOIuABAAAAzuLl4aFRMTFml2Gqi2Nj5enB2wUAsApesQEAAIBqJMTGyMNmM7sMU3jabLoo5hyzywAA1AMBDwAAAFCN9v7+SmilIUdCbIza+/ubXQYAoB4IeAAAAIAaTB9ynkIDAswuo1mFBgbo6iHnmV0GAKCeCHgAAACAGvj5+Oi3I4ebXUazumnECPl5e5tdBgCgngh4AAAAgFr0jYjQqNjWseHyxbEx6hMRbnYZAIAGIOABAAAA6jCjFSzVCg0M0PT4IWaXAQBoIAIeAAAAoA6tYakWS7MAwNoIeAAAAAAn9I2I0IwWOsPlmvghLM0CAIsj4AEAAACcNL5fX00c0N/sMlxq4sABuqxfX7PLAAA0EgEPAAAAUA9Tzx2sMX16m12GS4zp01tTBw8yuwwAgAt4mV0AAAAAYCU2m03XDY2Xr7e3Pt+6zexyGuzKgQM0ZfAg2Ww2s0sBALgAAQ8AAABQTzabTVedO1j+Pj5anJhkdjn1NiN+iMazLAsAWhQCHgAAAKCBxvfrq+4hIZq/Zq3yCgvNLqdOoYEBumnECDZUBoAWiD14AAAAgEboExGuR6ZM0qjYGLNLqdXFsTF6ZPIkwh0AaKGYwQMAAAA0kp+3t2YPv0DxUd31xpp1bjWbh1k7ANA6MIMHAAAAcJG+ERF6ZMokjY6LlYfJmxd72mwaHRfLrB0AaCWYwQMAAAC4kJ+3t2ZeMEwTBw7Q6pRUrUpNVX5RcbONH+zvp4tjY3VRzDlq7+/fbOMCAMxFwAMAAAA0gfb+/po8eJAmDBygzfsz9P3u3UrOPthk4/UJD9fouFgN6hYpLw8m6gNAa0PAAwAAADQhLw8PxUd1V3xUd2XlH9PGtDSl5f3/9u48Pqry7v//ezIhe0JIIEBIWARCVNB6syiyK0QRAYEqWmWrFFyget/e6l2tir1FcWvrzbdVqAh1RUWLLNKCFKJAEEL5WVzYtwQiJoEQsmcm5/cHzTRIltkyMyfzej4eeXjwXHN9PsPhmpPzmetcp1BHCwp1ttz9mT3xkZHq0jZR3RITNaBbNyXHt/Zi1gAAs6HAAwAAAPhIcnxr3XLVTxx/PlNWpqMFhTpaeP7ndGmpqu12VdvtstlrFGoNUSurVa2sViVER6trYuL5n7aJ3H4FALgABR4AAADAT9pERalN5yhd1TnV36kAAEyOm3MBAAAAAABMjgIPAAAAAACAyVHgAQAAAAAAMDkKPAAAAAAAACZHgQcAAAAAAMDkKPAAAAAAAACYHAUeAAAAAAAAk6PAAwAAAAAAYHIUeAAAAAAAAEyOAg8AAAAAAIDJUeABAAAAAAAwOQo8AAAAAAAAJhfq7wQAAAAAAN5h1NhUVXxQlae/VsXpPao8/bVsZd/LsFfKqKmSJSRMFmu4QqM6KDyhtyIS+ig8obfC4nrIEsLlIWBmjGAAAAAAMDHDMFSRn62iA2+rNHeDDHt5k6+xlZ1URcE/dPZff7ZYIxWdMkrxaVMU0bavLBZL8yYNwOso8AAAAACACdVUl6r46EqdPfCWqor2edSXYS9XybFVKjm2SmHx6YrvOUWxXccrpFW0l7IF0NxYgwcAAAAATObc8XU6unqY8nf+2uPizo9VFe3VDzsf19HVw3Tu+Dqv9g2g+VDgAQAAAACTsFUUKm/LHH2/5T7ZKwqbNZa9olDfb7lPeVvmyl5xulljAfAcBR4AAAAAMIGSnPU6vvYGlRxf69u4x9fo2NoMleSs92lcAK6hwAMAAAAAAa5o31LlfTFb9srmnbXTEHtlofK+mK2ifcv8Eh9A0yjwAAAAAEAAO/3NH5W/6zf+TkOSlL/raZ3+5o/+TgNAPSjwAAAAAECAKtq3VIVfvejvNC5Q+NWLzOQBAhAFHgAAAAAIQCU56wNm5s6P5e96mjV5gABDgQcAAAAAAoytolA/7HjM32k06oedj/F0LSCAUOABAAAAgACTn/2U3xZUdpa9olA/ZD/l7zQA/AsFHgAAAAAIIOeOf+rzR6G7q+T4Gp07vs7faQAQBR4AAAAACBg11aXKz37S32m4JD/7CdVUl/o7DSDoUeABAAAAgABx7ugnslcE9q1ZP2avKNS5Y5/4Ow0g6JmiwGOxWJz6GT58uFfivffee8rIyFCHDh0UERGhLl266K677lJWVpZX+gcAAACAHzMMQ0UH3vJ3Gm4p2v+WDMPwdxpAUDNFgcdXysvLNWbMGP3sZz/Thg0bdOrUKVVWVur48eN65513NHjwYD399NP+ThMAAABAC1SRn62qor3+TsMtVUV7VVGwy99pAEEt1N8JuOLee+/Vfffd1+D+6Ohoj/r/+c9/rk8//VSSNGLECD3wwANKTk7Wnj179Oyzz+rQoUOaN2+eOnbsqFmzZnkUCwAAAADqKjrwtr9T8EjR/rcU2a6fv9MAgpapCjxJSUnq3bt3s/T997//XcuXL5ckjR07Vn/5y19ktVolSf3799e4cePUt29fHT9+XI8++qhuvfVWtWnTpllyAQAAABBcjBqbSnM3+DsNj5TmbpBRY5MlxFSXmUCLwS1a//LSSy9JkkJDQ/XHP/7RUdyp1bZtWz3//POSpKKiIr3++us+zxEAAABAy1RVfFCGvdzfaXjEsJerqviQv9MAghYFHknnzp3Txo0bJUkjR45USkpKve0mTpyouLg4SdJf/vIXn+UHAAAAoGWrPP21v1PwipbyPgAzosAjaefOnaqqqpIkDRs2rMF2YWFhuuaaaxyvqa6u9kl+AAAAAFq2itN7/J2CV7SU9wGYkakKPB9++KEuu+wyRUVFKTY2Vj179tS0adO0adMmj/r99ttvHdvp6emNtq3db7PZdODAAY/iAgAAAIDUcma+tJT3AZiRqVa/qluIkaSDBw/q4MGDevPNN3XLLbdo2bJlat26tcv95ubmOrYbuj2rVmpqqmM7JydHl112mVtx6pOXl+d0XwAAAABaDlvZ9/5OwStsZVzTAP5iigJPVFSUxo0bp+uvv17p6emKiYlRfn6+MjMz9dprr6mwsFArV67U+PHjtWHDBrVq1cql/s+dO+fYjomJabRt3Uexl5SUuBSnbnEIAAAAAGoZ9kp/p+AVRk3LeB+AGZmiwHPixAnFx8df9P9HjRqluXPnavTo0dq9e7cyMzP16quv6pe//KVL/VdUVDi2w8LCGm0bHh7u2C4vN/cq9wAAAAACg1FT5e8UvMKwt4z3AZiRKQo89RV3arVv314rVqxQenq6qqurtXDhQpcLPBEREY7t2sWWG1JZ+e+KdGRkpEtxcnJyGt2fl5enAQMGuNQnAAAAAPOzhDT+RbNZWKwt430AZmSKAk9TLrnkEo0aNUqffvqpDh48qJMnTyo5Odnp18fGxjq2m7rtqrS01LHd1O1cP9bU+j4AAAAAgpPFGt50IxOwhLSM9wGYkameotWYuosdnzhxwqXX1i28NLUQct1ZOKypAwAAAMAbQqM6+DsFrwiN6ujvFICg1WIKPBaLxe3X1i0O7d27t9G2tftDQ0PVs2dPt2MCAAAAQK3whN7+TsErWsr7AMyoxRR46j5C3ZXbsySpf//+jsWVMzMzG2xXVVWl7du3O17j6tO6AAAAAKA+EQl9/J2CV7SU9wGYUYso8Bw5ckQbNmyQJHXv3l2dOnVy6fWxsbG6/vrrJUmfffZZg7dpffzxxyouLpYkTZgwwYOMAQAAAODfWsrMl5byPgAzCvgCz+rVq2Wz2Rrcf+rUKU2aNMnx9Kv77rvvojbLli2TxWKRxWLRvHnz6u3nv//7vyVJNptN999/v+x2+wX7CwoK9Oijj0o6/1SvmTNnuvN2AAAAAOAiYXE9ZLG69pTeQGOxRiosrru/0wCCVsA/RWvu3Lmqrq7WpEmTNHDgQHXt2lWRkZEqKCjQ5s2btWjRIhUUFEiSBg8erPvvv9+tONddd51uv/12LV++XKtWrdKoUaP04IMPKjk5WXv27NH8+fN1/PhxSdLzzz+vNm3aeO09AgAAAAhulpBQRaeMUsmxVf5OxW3RKaNkCQn4S0ygxTLF6Dt58qQWLlyohQsXNthm0qRJev311xUe7v5j+d544w0VFxfr008/1aZNm7Rp06YL9oeEhOiJJ57QrFmz3I4BAAAAAPWJ73mXqQs88WlT/J0CENQCvsDz5z//WZmZmcrKytLhw4dVUFCg4uJixcTEKDU1Vddee62mTZumgQMHehwrMjJSa9eu1bvvvqtly5bpq6++UlFRkdq3b68hQ4Zozpw5XokDAAAAAD8W0a6fwuLTVVXU+JN9A1FY/KWKaNvX32kAQc1iGIbh7yRwXm5urlJTUyVJOTk5SklJ8XNGAAAAAHzp7IF39cPOx/2dhsuSBsxX6x4/83cagNNa4vV3wC+yDAAAAADBIrbreFkjEv2dhkusEYmK7TLe32kAQY8CDwAAAAAEiJBW0WrX73/9nYZLkvo/o5BW0f5OAwh6FHgAAAAAIIDEdh6tmM5j/J2GU2I636yY1Bv9nQYAUeABAAAAgIDTrt/TsoYH9q1a1ohEJfV72t9pAPgXCjwAAAAAEGBCIxKVNOBZf6fRqKT+z8oakeDvNAD8CwUeAAAAAAhAMakZatf3SX+nUa92fZ9STGqGv9MAUAcFHgAAAAAIUPG9Zijxyof9ncYFEq98RPG9pvs7DQA/QoEHAAAAAAJYwuX3qV3fp/ydhiSpXd95Srj8Xn+nAaAeFHgAAAAAIMDF95qujkMW+W3hZWtEojoOWaT4XtP8Eh9A0yjwAAAAAIAJxKRmqMuY9YrpfLNv43YZqy43rWfNHSDAUeABAAAAAJOwRiSo4+CF6jD4j7JGNO9snvOzdl5Vx0H/x9OyABMI9XcCAAAAAADXxHYereiOQ3Xu6CcqOvCWqor2eq3vsPh0xadNUWyX8QppFe21fgE0Lwo8AAAAAGBCIa2i1brnzxTX4w5VFOxS0f63VJq7QYa93OW+LNZIxaRkqHXaFEW0/Q9ZLJZmyBhAc6LAAwAAAAAmZrFYFNmunyLb9ZNRY1NV8SFVnv5aFaf3qPL017KV5cmoqZRhr5LFGiZLSLhCozoqPKG3IhL6KDyht8LiussSwuUhYGaMYAAAAABoISwhoQqP76Xw+F6Ku2SSv9MB4EMssgwAAAAAAGByFHgAAAAAAABMjgIPAAAAAACAyVHgAQAAAAAAMDkKPAAAAAAAACZHgQcAAAAAAMDkKPAAAAAAAACYHAUeAAAAAAAAk6PAAwAAAAAAYHIUeAAAAAAAAEyOAg8AAAAAAIDJUeABAAAAAAAwOQo8AAAAAAAAJkeBBwAAAAAAwOQo8AAAAAAAAJgcBR4AAAAAAACTo8ADAAAAAABgchR4AAAAAAAATI4CDwAAAAAAgMlR4AEAAAAAADA5CjwAAAAAAAAmR4EHAAAAAADA5CjwAAAAAAAAmBwFHgAAAAAAAJOjwAMAAAAAAGByFHgAAAAAAABMjgIPAAAAAACAyVHgAQAAAAAAMDkKPAAAAAAAACZHgQcAAAAAAMDkKPAAAAAAAACYHAUeAAAAAAAAk6PAAwAAAAAAYHIUeAAAAAAAAEyOAg8AAAAAAIDJUeABAAAAAAAwOQo8AAAAAAAAJkeBBwAAAAAAwOQo8AAAAAAAAJgcBR4AAAAAAACTo8ADAAAAAABgchR4AAAAAAAATI4CDwAAAAAAgMlR4AEAAAAAADA5CjwAAAAAAAAmR4EHAAAAAADA5CjwAAAAAAAAmBwFHgAAAAAAAJOjwAMAAAAAAGByFHgAAAAAAABMjgIPAAAAAACAyVHgAQAAAAAAMDkKPAAAAAAAACZHgQcAAAAAAMDkKPAAAAAAAACYnCkKPNnZ2frNb36jjIwMpaSkKDw8XDExMUpLS9OMGTO0ZcsWr8SZN2+eLBaLUz+bN2/2SkwAAAAAAABPhfo7gaYMHTpUX3zxxUX/v6qqSgcOHNCBAwe0bNkyTZ06VX/6058UFhbmhywBAAAAAAD8J+ALPCdPnpQkJScn69Zbb9WQIUPUuXNn2e12ZWVl6eWXX9aJEyf05ptvqrq6Wu+++65X4u7Zs6fR/d26dfNKHAAAAAAAAE8FfIEnPT1dzz77rCZNmiSr1XrBvmuuuUZTpkzRoEGDtH//fr333nu65557NHToUI/j9u7d2+M+AAAAAAAAfCHg1+BZs2aNbrvttouKO7Xatm2rl19+2fHnFStW+Co1AAAAAACAgBDwBR5njBgxwrF96NAhP2YCAAAAAADgey2iwFNZWenYbmimDwAAAAAAQEvVIgo8mZmZju1LL73UK31mZGQoKSlJYWFhSkpK0vDhw7VgwQKdOXPGK/0DAAAAAAB4S8AvstyUmpoaLViwwPHn2267zSv9btiwwbGdn5+vzMxMZWZm6vnnn9eyZcs0fvx4l/vMzc1tdH9eXp7LfQIAAAAAAJi+wPO73/1OO3bskCRNnDhRffv29ai/Pn366JZbbtGAAQOUnJys6upq7du3T++8847Wr1+voqIiTZo0SatXr9bo0aNd6js1NdWj3AAAAAAAAOpjMQzD8HcS7srMzNTIkSNls9mUlJSkPXv2KCkpye3+ioqKFB8f3+D+RYsW6Z577pEkJScn69ChQ4qIiHC6f4vF4nTbnJwcpaSkON0eAAAAAAA4Jzc31zEJo6Vcf5t2Bs8333yjCRMmyGazKSIiQh9++KFHxR1JjRZ3JGn27NnauXOnlixZopMnT+qjjz7SnXfe6XT/OTk5je7Py8vTgAEDnO4PAAAAAABAMmmB58iRI8rIyNCZM2dktVq1fPlyDR061CexZ8+erSVLlkg6P4PIlQJPS6gIAgAAAACAwGO6p2idPHlSI0eO1MmTJ2WxWPTGG2+4teCxuy677DLH9okTJ3wWFwAAAAAAoCGmmsFTUFCgUaNG6fDhw5KkhQsXaurUqT7NwZV1dGA+Nnu1DhzZo0PHv9GRnL06XXRKNnu1Qq2tlBDfXt1S09W98+Xq2a2PQq2t/J0uAAAAAACSTFTgOXv2rG644QZ9++23kqQFCxbo/vvv93ketfGl8wsto2U4XXRKG7Z8pI3bPlZRcUGD7b7YuVaSFB/XViMHTdTIQZOUEN/eV2kCAAAAAFAvUxR4ysrKNGbMGP3jH/+QJD3++ON69NFH/ZLLokWLHNvDhg3zSw7wHrvdpk82LNWKvy6WzVbt9OuKigu0Yt1irdywVD+9cZbGj5ohq9UUwwkAAAAA0AIF/Bo8VVVVmjBhgrZu3SpJeuCBB/TMM8+43M+yZctksVhksVg0b968i/bv2bNHBw8ebLSPxYsX6/XXX5ckdejQQRMmTHA5DwSOvB+O6fGXpmr5mj+4VNypy2ar1vI1f9DjL01V3g/HvJwhAAAAAADOCfgpB3fccYfWr18vSbruuut099136+uvv26wfVhYmNLS0lyOs2vXLs2cOVMjRozQ6NGj1adPHyUmJspms2nv3r165513HHlYrVYtXrxY0dHR7r0p+N3R3H165v/do+KSM17p73DOt3rydzP0+P2vqmtKL6/0CQAAAACAswK+wPPxxx87tv/+97/riiuuaLR9ly5ddPToUbdi2e12ffbZZ/rss88abJOYmKglS5Zo7NixbsWA/+X9cMyrxZ1aZ8+d1jP/7x79738tU8ekLl7tGwAAAACAxgR8gcdXbrrpJi1ZskRZWVnavXu3Tp06pcLCQhmGoYSEBF155ZW68cYbNX36dMXFxfk7XbjJZq/WK0t/5fXiTq3ikjP6v2W/0jMPvcmaPAAAAAAAn7EYhmH4Owmcl5ubq9TUVElSTk6OUlJS/JxRy/PxX/+k5Wv+0Oxxbh87RxNvmNnscQAAAAAArmuJ198Bv8gy4C2ni05pxV8X+yTWinWLdLrolE9iAQAAAABAgQdBY8OWj9x+WparbLZqfbb1I5/EAgAAAACAAg+Cgs1erY3bPm66oRd9tvVj2ey+KSgBAAAAAIIbBR4EhQNH9qiouMCnMYuKC3Tw6Nc+jQkAAAAACE4UeBAUDh3/JqjiAgAAAACCCwUeBIUjOXv9Evfw8e/8EhcAAAAAEFwo8CAo+OuJVjxJCwAAAADgCxR4EBT8tdgxiywDAAAAAHyBAg+CQqi1VVDFBQAAAAAEFwo8CAoJ8e2DKi4AAAAAILhQ4EFQ6Jaa7pe4l3S+1C9xAQAAAADBhQIPgkL3zpcHVVwAAAAAQHChwIOg0LNbH8XHtfVpzPi4turRtbdPYwIAAAAAghMFHgSFUGsrXX/tRJ/GHDloIossAwAAAAB8ggIPgsaowZMUGuqbgktoaCuNHDTJJ7EAAAAAAKDAg6CREN9eP71xlk9i/XT0bJ6gBQAAAADwGQo8CCrjR83QJamXNWuM7p0v0/iR05s1BgAAAAAAdVHgQVCxWkP1wIznFBfTpln6bx2boF9Of05Wa2iz9A8AAAAAQH0o8CDodEzqol/Pec3rRZ7WsQn69ZzX1DGpi1f7BQAAAACgKUwzQFDqmtJL//tfy/TK0l/pcM63HvfXvfNl+uX05yjuAAAAwK+MGpuqig+q8vTXqji9R5Wnv5at7HsZ9koZNVWyhITJYg1XaFQHhSf0VkRCH4Un9FZYXA9ZQrg8BMyMEYyg1TGpi+b/95v65LNlWrFukWy2apf7CA1tpZ+Onq3xI6dzWxYAAAD8wjAMVeRnq+jA2yrN3SDDXt7ka2xlJ1VR8A+d/defLdZIRaeMUnzaFEW07SuLxdK8SQPwOq5IEdSs1lBNvGGmhl89Vp9t/Uifbf1YRcUFTb6uTVw7XT9ookYOmsjTsgAAAOAXNdWlKj66UmcPvKWqon0e9WXYy1VybJVKjq1SWHy64ntOUWzX8QppFe2lbAE0N4thGIa/k8B5ubm5Sk1NlSTl5OQoJSXFzxkFH5u9WgePfq1Dx7/R4ePf6XTRKdns1Qq1tlJCfHtd0vlSde98uXp07a1Qayt/pwsAAIAgde74OuVnPyF7RWGzxbBGJKpdv/9VbOfRzRYD8JeWeP3NDB6gjlBrK6V3v0rp3a/ydyoAAADARWwVhcrPfkolx9c2eyx7RaG+33KfSjrfrKR+T8sakdDsMQG4j6doAQAAAIAJlOSs1/G1N/ikuHNB3ONrdGxthkpy1vs0LgDXUOABAAAAgABXtG+p8r6YLXtl892S1Rh7ZaHyvpiton3L/BIfQNMo8AAAAABAADv9zR+Vv+s3/k5DkpS/62md/uaP/k4DQD0o8AAAAABAgCrat1SFX73o7zQuUPjVi8zkAQIQBR4AAAAACEAlOesDZubOj+Xvepo1eYAAw1O0AAAAACDA2CoK9cOOx9x+vb1Gyimx6kSJVSdLrTpbGSK7IVktUuvwGiVH29Upxq7UGLusbn7t/8POxxTZrh9P1wICBAUeAAAAAAgw+dlPubWg8tlKi3aeCtPOU2EqqW64cvP/5Z//b0yrGvVvX6X+7avUOtxwKZa9olA/ZD+ljoMXupwnAO+jwAMAAAAAAeTc8U9dfhS63ZA+PxGuTTnhshsWp19XUh2iTbkR+vxEuEakVmpop0pZnX+5So6v0bnjNym282iX8gXgfazBAwAAAAABoqa6VPnZT7r0moLyEL32z2h9djzCpeJOXXbDos+OR+i1f0aroNy1y8T87CdUU13qVlwA3kOBBwAAAAACxLmjn8he4fytWXmlIVq8J1onS71zc8bJ0lAt/jpaeaXOXyraKwp17tgnXokPwH0UeAAAAAAgABiGoaIDbzndvqA8REu/iVapzbuXdaXV5/t1ZSZP0f63ZBiureEDwLso8AAAAABAAKjIz1ZV0V6n2tprpPf3R3q9uFOr1BaiD/ZHyu5kzaaqaK8qCnY1Sy4AnEOBBwAAAAACQNGBt51u+/nJcK/dltWQE6Wh+uJEuNPti/Y7P/sIgPdR4AEAAAAAPzNqbCrN3eBU27OVFm3Kcb7w4om/54TrbKVzCzeX5m6QUWNr5owANIQCDwAAAAD4WVXxQRn2cqfa7jwV5vbTslxlNyzaeSrMqbaGvVxVxYeaOSMADaHAAwAAAAB+Vnn6a6fa2WvkdMHFW3aeCpO9xrm2zr4PAN5HgQcAAAAA/Kzi9B6n2uWUWFVS7dvLuJLqEOWUWJ1q6+z7AOB9FHgAAAAAwM+cnflywslCi7c5G5cZPID/UOABAAAAAD+zlX3vVLuTpf4p8Dgb11aW18yZAGgIBR4AAAAA8DPDXulUu7OV/rmEczauUePc+wDgfRR4AAAAAMDPjJoqp9rZjWZOxMO4ht259wHA+yjwAAAAAICfWUKcezKW1TdPR3c7rsXq2yd8Afg3CjwAAAAA4GcWa7hT7VqHO/m8ci9zNq4lxLn3AcD7KPAAAAAAgJ+FRnVwql1ytL2ZM/EsbmhUx2bOBEBDKPAAAAAAgJ+FJ/R2ql2nGP8UeJyN6+z7AOB9FHgAAAAAwM8iEvo41S41xq6YVr69TSumVY1SnSzwOPs+AHgfBR4AAAAA8DNnZ75YQ6T+7X37pKr+7atkdfLKkRk8gP9Q4AEAAAAAPwuL6yGLNdKptv3bV8lq8c3z0q0Ww+mCksUaqbC47s2cEYCGUOABAAAAAD+zhIQqOmWUU21bhxsakVrZzBmdd11qpVqHO1dMik4ZJUtIaDNnBKAhFHgAAAAAIADE97zL6bZDO1UqOdrWjNlInaJtGtLJ+UJSfNqUZswGQFMo8AAAAABAAIho109h8elOtbVapMlp5YoObZ4Fl6Nb1ei2tHJZLc61D4u/VBFt+zZLLgCcQ4EHAAAAAAKAxWJRfE/nZ8G0jazRjMtLvV7kiW5Vo59fVqq2kc73G592lywWJ6tBAJoFBR4AAAAACBCxXcfLGpHodPuO0TWa1afUa7drdYq2aVbvUnWIdr64Y41IVGyX8V6JD8B9FHgAAAAAIECEtIpWu37/69Jr2kbW6J4rSjWqc4XbT9eyWgyN6lyh2Ve4NnNHkpL6P6OQVtFuxQXgPSxxDgAAAAABJLbzaJV0HqOS42udfo3VIg1PqdRV7aq081SYdp4KU0l109/nx7aqUf/2VerXvsrpp2XVFdP5ZsWk3ujy6wB4HwUeAAAAAAgw7fo9rfJT22WvLHTpda3DDY3sXKkRKZXKKbHqRIlVJ0utOlsZIrtxvhDUOrxGydF2dYqxKzXGLqub93VYIxKV1O9p914MwOso8AAAAABAgAmNSFTSgGeV98Vst15vDZG6xtnVNc7u5cz+Lan/s7JGJDRb/wBcwxo8AAAAABCAYlIz1K7vk/5Oo17t+j6lmNQMf6cBoA4KPAAAAAAQoOJ7zVDilQ/7O40LJF75iOJ7Tfd3GgB+hAIPAAAAAASwhMvvU7u+T/k7DUlSu77zlHD5vf5OA0A9KPAAAAAAQICL7zVdHYcskjU80S/xrRGJ6jhkkeJ7TfNLfABNo8ADAAAAACYQk5qhLmPWK6bzzb6N22Wsuty0njV3gABHgQcAAAAATMIakaCOgxeqw+A/yhrRvLN5zs/aeVUdB/0fT8sCTIDHpAMAAACAycR2Hq3ojkN17ugnKjrwlqqK9nqt77D4dMWnTVFsl/EKaRXttX4BNC8KPAAAAABgQiGtotW6588U1+MOVRTsUtH+t1Sau0GGvdzlvizWSMWkZKh12hRFtP0PWSyWZsgYQHOiwAMAAAAAJmaxWBTZrp8i2/WTUWNTVfEhVZ7+WhWn96jy9NeyleXJqKmUYa+SxRomS0i4QqM6KjyhtyIS+ig8obfC4rrLEsLlIWBmjGAAAAAAaCEsIaEKj++l8Pheirtkkr/TAeBDpltk+dixY3rooYeUnp6u6OhoJSQkqH///nrxxRdVVlbmtTjr1q3ThAkTlJKSovDwcKWkpGjChAlat26d12IAAAAAAAB4g8UwDMPfSThr9erVuuuuu1RcXFzv/rS0NK1du1Y9evRwO0ZNTY1mzZqlJUuWNNhm5syZWrRokUJCvFsfy83NVWpqqiQpJydHKSkpXu0fAAAAAAC0zOtv08zg2b17tyZPnqzi4mLFxMRo/vz52rZtmzZu3Khf/OIXkqT9+/drzJgxOnfunNtxHn/8cUdx56qrrtJ7772nHTt26L333tNVV10lSXr99df161//2vM3BQAAAAAA4AWmmcEzdOhQffHFFwoNDdXnn3+ugQMHXrD/xRdf1COPPCJJeuqppzRv3jyXY+zfv1+XX365bDab+vXrp88//1yRkZGO/WVlZRo2bJiys7MVGhqq7777zqPZQj/WEiuIAAAAAAAEmpZ4/W2KGTw7duzQF198IUm6++67LyruSNJDDz2kSy+9VJL0yiuvqLq62uU4v//972Wz2SRJCxcuvKC4I0lRUVFauHChJMlms+l3v/udyzEAAAAAAAC8zRQFnpUrVzq2Z8yYUW+bkJAQTZ06VZJUVFSkTZs2uRTDMAx98sknkqT09HRdc8019ba75ppr1KtXL0nSJ598IpNMgAIAAAAAAC2YKQo8W7ZskSRFR0erb9++DbYbNmyYY3vr1q0uxThy5IhOnjx5UT+NxTlx4oSOHj3qUhwAAAAAAABvM0WB57vvvpMk9ejRQ6GhoQ22S09Pv+g1zvr222/r7cfbcQAAAAAAALyt4WpJgKioqFBBQYEkNbnoUZs2bRQdHa3S0lLl5OS4FCc3N9ex3VSc2oWYJLkUp26M+tTtKy8vz+l+AQAAAACA8+pec9euxWt2AV/gqfvI85iYmCbb1xZ4SkpKmi1OdHS0Y9uVOHULQ00ZMGCA020BAAAAAIB78vPz1bVrV3+n4bGAv0WroqLCsR0WFtZk+/DwcElSeXl5s8WpjeFOHAAAAAAAEDhOnTrl7xS8IuBn8ERERDi2q6qqmmxfWVkpSRc94tybcWpjuBqnqdu5jhw5oqFDh0qStm3b5tKMH5hPXl6eY6bWjh071LFjRz9nhObE8Q4uHO/gwvEOLhzv4MLxDi4c7+CSk5Oja6+9VlLT6/CaRcAXeGJjYx3bztwOVVpaKsm527ncjVMbw9U4Ta3tU1dqaqpL7WFuHTt25HgHEY53cOF4BxeOd3DheAcXjndw4XgHl7oTPsws4G/RioiIUGJioqSmFyk+c+aMo/ji6uyXuoPXlcWQmWUDAAAAAAD8LeALPJJ02WWXSZIOHjzY6OrWe/fudWxfeumlbsX4cT/ejgMAAAAAAOBtpijwDB48WNL5W6N27drVYLvMzEzH9qBBg1yK0a1bNyUnJ1/UT30+//xzSVKnTp1axErbAAAAAADA3ExR4Lnlllsc20uXLq23TU1Njd58801JUnx8vEaMGOFSDIvFovHjx0s6P0Nn+/bt9bbbvn27YwbP+PHjZbFYXIoDAAAAAADgbaYo8AwYMEBDhgyRJC1ZskRZWVkXtXn55Zf13XffSZIeeOABtWrV6oL9mzdvlsVikcVi0fTp0+uN8+CDD8pqtUqS5s6de9Ej0MvLyzV37lxJUmhoqB588EFP3hYAAAAAAIBXmKLAI0mvvPKKIiMjZbPZlJGRoeeee07bt2/Xpk2bNHv2bD3yyCOSpLS0ND300ENuxUhLS9PDDz8sScrOztagQYP0/vvvKzs7W++//74GDRqk7OxsSdLDDz+snj17eufNAQAAAAAAeCDgH5Ne66qrrtL777+vu+66S8XFxXrssccuapOWlqa1a9de8MhzV82fP18//PCD3njjDe3evVu33377RW3uvvtuPfPMM27HAAAAAAAA8CaLYRiGv5NwxbFjx/TKK69o7dq1ys3NVVhYmHr06KFbb71Vc+bMUVRUVL2v27x5s2NdnmnTpmnZsmWNxvn000+1ePFi7dy5UwUFBWrbtq369++v2bNna/To0d5+WwAAAAAAAG4zXYEHAAAAAAAAFzLNGjwAAAAAAACoHwUeAAAAAAAAk6PAAwAAAAAAYHIUeAAAAAAAAEyOAg8AAAAAAIDJUeABAAAAAAAwOQo8AAAAAAAAJkeBBwAAAAAAwOQo8DSDY8eO6aGHHlJ6erqio6OVkJCg/v3768UXX1RZWZnX4qxbt04TJkxQSkqKwsPDlZKSogkTJmjdunVei4H6ZWdn6ze/+Y0yMjIcf/8xMTFKS0vTjBkztGXLFq/EmTdvniwWi1M/mzdv9kpMXMzZYzB8+HCvxHvvvfeUkZGhDh06KCIiQl26dNFdd92lrKwsr/SPxg0fPtzpY+7J+GN8N78ffvhBa9as0ZNPPqnRo0erbdu2jr/T6dOnu9yfr867ZWVleuGFF9S/f38lJCQoOjpa6enpeuihh3Ts2DGvxmppvHHMy8rK9PHHH+vee+9V//791aZNG7Vq1UqJiYkaOHCg5s2bp++//94r+Xbt2tWpz4CuXbt6JV5L443jvWzZMqc/i5ctW+aVvAsKCvTkk0/qiiuuUFxcnOLi4nTFFVfoySefVGFhoVditESeHu+jR4+6fH73ZOwxvt3n7WutoDp/G/CqVatWGXFxcYaken/S0tKMAwcOeBTDbrcbd999d4MxJBkzZ8407Ha7l94V6hoyZEijf/e1P1OnTjUqKys9ivXUU085FUuSsWnTJu+8QVzE2WMwbNgwj+KUlZUZN910U4P9h4SEGPPmzfPOm0KDhg0b5vQxrz0uubm5LsdhfDe/xv5Op02b5nQ/vjzvHjhwwOjZs2eDceLi4ozVq1d7HKel8vSYf/XVV0ZMTEyTYzIuLs5Yvny5x/l26dLFqc+ALl26eByrJfLGGF+6dKnTn8VLly71OOft27cbHTp0aDBGx44djS+//NLjOC2Rp8f7yJEjLp3fJRkZGRlu58v4do83r7WC8fwdKnjN7t27NXnyZJWXlysmJka/+tWvNGLECJWXl2v58uX605/+pP3792vMmDHKzs5WbGysW3Eef/xxLVmyRJJ01VVX6ZFHHlH37t116NAhvfDCC9q9e7def/11tWvXTs8++6w33yIknTx5UpKUnJysW2+9VUOGDFHnzp1lt9uVlZWll19+WSdOnNCbb76p6upqvfvuu16Ju2fPnkb3d+vWzStx0LB7771X9913X4P7o6OjPer/5z//uT799FNJ0ogRI/TAAw8oOTlZe/bs0bPPPqtDhw5p3rx56tixo2bNmuVRLDRs6dKlKi0tbbTNt99+q8mTJ0uSrr/+enXq1MmjmIzv5te5c2elp6dr/fr1Lr/WV+fdc+fOacyYMTpw4IAk6Re/+IVuv/12RUZGatOmTXruuedUXFysyZMna+vWrfrJT37idqxg4M4xLy4uVklJiSRp0KBBuvnmm9WvXz8lJiYqPz9fH3/8sf70pz+puLhYd955p+Li4jR69GiPcx0/fryeeeaZBveHhYV5HKOl82SM1/rb3/6m5OTkBvenpKS43bck5eTkaOzYscrPz1doaKj+67/+SzfffLMkac2aNfrtb3+rvLw8jR07Vrt27fI4XkvmzvHu1KlTk+dbSXruueccv79PmzbN7RxrMb5d481rraA8fzd7CSmI1FYbQ0NDjW3btl20/4UXXnBU8J566im3Yuzbt88IDQ01JBn9+vUzysrKLthfWlpq9OvXz5GHp7OFcLExY8YY77//vmGz2erdn5+fb6SlpTmOdWZmptux6n7DD//xdNw6Y+PGjY44Y8eOvejfV35+vtG5c2dDkhEfH2+cPn262XJB0x555BHH8Xrrrbfc6oPx3fyefPJJY/Xq1cb3339vGMaF3946++2+L8+7TzzxhCO/F1544aL9W7dudeTi6YzBlsrTY75161bjtttuM7755psG26xcudKwWCyGJKN79+5GTU2N2/nWfsPvyowy/Js3xnjdGTxHjhxpvmQNw5gyZYoj1gcffHDR/vfff9/l/IOJN453U2w2m5GcnGxIMmJjYy/6zHcF49s93rrWCtbzN79VesmXX37pOKizZ8+ut43dbjcuvfRSxwVaVVWVy3HuvfdeR5ysrKx622RlZTna3HfffS7HgOdWr17tOAZz5851ux8uAAODLwo8o0ePdpxgcnJy6m3z3nvvNXrygG/Y7XajU6dOhiQjJibGKC0tdasfxrfvuXMx4KvzblVVldG6dWtDknHppZc2OF189uzZjlg7duxwK1YwaY4LQMMwjEmTJjn63bVrl9v9cAHoXYFc4MnLyzNCQkIMScYNN9zQYLsbbrjBkM7f/puXl9ds+bQEzTG+//rXvzr6nDFjhkd9Mb6bjzPXWsF6/maRZS9ZuXKlY3vGjBn1tgkJCdHUqVMlSUVFRdq0aZNLMQzD0CeffCJJSk9P1zXXXFNvu2uuuUa9evWSJH3yyScyDMOlOPDciBEjHNuHDh3yYyYwg3Pnzmnjxo2SpJEjRzY4JXvixImKi4uTJP3lL3/xWX640MaNG3XixAlJ0k9/+lNFRUX5OSM0F1+edzdt2qSzZ89KOn9LQEhI/b+i1V1IlM8B/+E8D1etWrVKNTU1khq+VpD+PcZramq0atUqX6SGOt58803Htjduz0LzaOozOJjP3xR4vKR2Je/o6Gj17du3wXbDhg1zbG/dutWlGEeOHHHck1i3n8binDhxQkePHnUpDjxXWVnp2LZarX7MBGawc+dOVVVVSWp8bIeFhTlOUDt37lR1dbVP8sOF6v7yV1u0R8vky/Nu3SeCNBarX79+jqKiq79HwHs4z8NVzo5xT64V4Jlz5845vrTv2rWrhg4d6t+E0KCmPoOD+fxNgcdLvvvuO0lSjx49FBra8NrV6enpF73GWd9++229/Xg7DjyXmZnp2L700ku90mdGRoaSkpIUFhampKQkDR8+XAsWLNCZM2e80j+a9uGHH+qyyy5TVFSUYmNj1bNnT02bNs3l2Xg/5s7YttlsjoXc4DslJSWOb126dOmi4cOHe6Vfxndg8uV519lYoaGh6tGjh9tx4B3ePs9//vnn+slPfqLY2FhFRUWpW7dumjx5slauXMlMbB+aMWOGkpOTFRYWprZt2+qaa67Rr3/9a8esTU/UjvHWrVurQ4cODbbr2LGjY7YuY9y3VqxYobKyMknSlClTZLFYvNIv49v7mvoMDubzNwUeL6ioqFBBQYGkplfXb9OmjeNJOzk5OS7Fyc3NdWw3FSc1NdWx7WoceKampkYLFixw/Pm2227zSr8bNmxQfn6+qqurlZ+fr8zMTP3qV7/SJZdc4piCiOb17bff6rvvvlN5eblKSkp08OBBvfnmm7ruuus0YcIEx/RMVzG2zeOjjz5yPGHrrrvu8tovf4zvwOTLsVkbKzo6WvHx8U7Fys/Pv+BbTPjGV199pbVr10qS+vTp45UCz5EjR/TVV1+ppKRE5eXlOnr0qD744ANNmDBBQ4YM8UqBAU3bvHmz8vLyVF1drcLCQn355ZeaP3++evTooUWLFnnUd+0Yd+bJWLVjnPO8bzXXDF3Gt3c5c60VzOdvHpPuBefOnXNsx8TENNk+OjpapaWljsdwNkecuo9rdjUOPPO73/1OO3bskHR+zZTGbtlzRp8+fXTLLbdowIABSk5OVnV1tfbt26d33nlH69evV1FRkSZNmqTVq1d75VGtuFhUVJTGjRun66+/Xunp6YqJiXFchL/22msqLCzUypUrNX78eG3YsEGtWrVyqX/Gtnl4+5c/xndg8+XYrI3l7O8RdWOFh4e7HA/uqays1MyZM2W32yVJ8+fP96i/sLAwjRs3ThkZGerdu7dat26toqIiZWVl6dVXX1VOTo62bt2qUaNGKSsrS61bt/bG28CPXHLJJZo4caIGDhzouAA7fPiwPvroI61YsUIVFRW65557ZLFYNGvWLLdiuDPGOc/7zvHjxx2zQq699lrHTAtPML6bhzPXWsF8/qbA4wUVFRWO7bCwsCbb1x7I8vLyZotT9x+Lq3HgvszMTP3P//yPJCkpKUmvvvqqR/09+OCDmjdv3kX//+qrr9bUqVO1aNEi3XPPPbLb7Zo5c6YOHTqkiIgIj2LiYidOnKi3Ij9q1CjNnTtXo0eP1u7du5WZmalXX31Vv/zlL13qn7FtDrm5udq8ebOk84vypaWledQf4zvw+XJs1sZy5fcId2PBfXPmzFF2drak84tpjh071qP+duzYUe/5Zfjw4ZozZ45++tOfav369fruu+/09NNP67e//a1H8XCxCRMmaNq0aRfNyOzfv78mT56sNWvWaOLEiaqurtZ//ud/aty4cY3eYtUQd8Y449t33n77bcftUt6avcP49j5nr7WC+fzNLVpeUPcX7tqFUhtTOx0rMjKy2eLUnfLlahy455tvvtGECRNks9kUERGhDz/8UElJSR712dQ0v9mzZ+vuu++WJJ08eVIfffSRR/FQv8aOQ/v27bVixQrHrJ2FCxe63D9j2xzefvttxxNQvPFkDcZ34PPl2KyN5crvEe7Ggnuee+45vf7665LOX/z/4Q9/8LjPxj4HYmNj9cEHHyghIUGStHjxYqf+fcA1rVu3bvR225tvvllPPvmkJKmsrExLlixxK447Y5zx7TtvvfWWpPMX4JMnT/ZKn4xv73LlWiuYz98UeLwgNjbWse3MtK7a9RucmcblbpzaGO7EgeuOHDmijIwMnTlzRlarVcuXL/fZyvuzZ892bNddcAy+c8kll2jUqFGSpIMHDzpW7XcWY9scmuOXv6Ywvv3Ll2OzNpYrv0e4GwuuW7RokR577DFJ5xfR/PTTTy+Yat9cWrdurdtvv13S+eNeO3sIvjVr1ixHEcjdz2J3xjjj2zd27NihvXv3SpLGjRvX5Bcw3sL4dp6r11rBfP6mwOMFERERSkxMlHThgk71OXPmjOPA1l3QyRl1F4hqKk7dBaJcjQPXnDx5UiNHjtTJkydlsVj0xhtvaPz48T6Lf9lllzm2WaTNfzw5DoztwJedne14SsLNN9+sNm3a+CQu49u/fDk2a2OVlpaqqKjIqVjt2rVj/R0feO+993TfffdJOv/0vA0bNqht27Y+i8/ngP8lJSU5ftd39xjUjvGmPkukf49xzvO+0VyLKzuD8d00d661gvn8TYHHS2oH58GDB2Wz2RpsV1sdllx/rGbdD4C6/Xg7DpxXUFCgUaNG6fDhw5LO357j6xODt57iA894chzcGduhoaHq2bOn2zHhmrq//Hnj9ixnMb79y5fnXWdj2Ww2HTp0yO04cM2qVas0depU1dTUqGPHjtq4caNTT0HyJj4HAoOnx6F2jJ89e1bff/99g+3y8vJUXFwsiTHuC9XV1Vq+fLmk84W8G2+80afxGd+Nc/daK5jP3xR4vGTw4MGSzlfudu3a1WC7utM6Bw0a5FKMbt26KTk5+aJ+6vP5559Lkjp16qSuXbu6FAfOOXv2rG644QbHt/oLFizQ/fff7/M8auNLcvz7gO95chz69+/vWJitsbFdVVWl7du3O17j6tO64J66v/y1a9fOp0+zYnz7ly/Pu7W/RzQVKzs72zET2NXfI+CajRs36rbbbpPNZlNiYqI2bNig7t27+zwPPgf8Lz8/XwUFBZLcPwbOjnFPrhXgurVr16qwsFCS9LOf/Uyhob59BhHju2GeXGsF8/mbAo+X3HLLLY7tpUuX1tumpqbG8S1wfHy8RowY4VIMi8XimI62d+9ex4Xej23fvt1RPRw/fjyV4WZQVlamMWPG6B//+Ick6fHHH9ejjz7ql1wWLVrk2B42bJhfcgh2R44c0YYNGyRJ3bt3V6dOnVx6fWxsrK6//npJ0meffdbgVNKPP/7Y8a3ehAkTPMgYrli3bp3y8/Ml+f6XP8a3f/nyvDt8+HDHI3L//Oc/O57m8mPLli1zbPM50Hy2bdum8ePHq7KyUq1bt9bf/vY3XX755T7P4+zZs44Cc1RUlPr16+fzHHB+AdzaMenuZ/G4ceMUEnL+0quhawXp32M8JCRE48aNcysWnOevGboS47sxnl5rBfX524DXDBkyxJBkhIaGGtu2bbto/wsvvGBIMiQZTz311EX7N23a5Ng/bdq0emPs27fPsFqthiSjX79+RllZ2QX7y8rKjH79+jny2L9/vzfeGuqorKw0MjIyHMfqgQcecKufpUuXNvrv4Z///Kdx4MCBRvtYtGiRo48OHToYJSUlbuWChq1atcqorq5ucP/3339vXHXVVY7j8PLLL1/UpqljbRiGsXHjRkebcePGGTab7YL9+fn5RufOnQ1JRnx8vHH69GmP3hecN2nSJMex2bVrl1OvYXwHpiNHjjR5nv0xb513p02b5oi9adOmets88cQTjjYvvPDCRfu3bdtmhIaGGpKMYcOGOZV/sHPnmO/evduIj483JBnR0dHGli1b3Io9bNgwR+wjR45ctH/dunUX/Xuq69y5cxf8vjF37ly38ggmrh7vI0eOGP/4xz8abbN69WojLCzMkGRERkYaubm59bZr6ngbhmFMmTLF0ebDDz+8aP8HH3zg8r/XYObO+K6rsLDQcWz79Onj0msZ383HW9dawXr+9u0ctBbulVde0aBBg1ReXq6MjAw99thjGjFihMrLy7V8+XItXrxYkpSWlqaHHnrIrRhpaWl6+OGHtWDBAmVnZ2vQoEF69NFH1b17dx06dEjPP/+8du/eLUl6+OGHWaOjGdxxxx1av369JOm6667T3Xffra+//rrB9mFhYUpLS3M5zq5duzRz5kyNGDFCo0ePVp8+fZSYmCibzaa9e/fqnXfeceRhtVq1ePFinzzRI9jMnTtX1dXVmjRpkgYOHKiuXbsqMjJSBQUF2rx5sxYtWuSYtj148GC3b9O77rrrdPvtt2v58uVatWqVRo0apQcffFDJycnas2eP5s+fr+PHj0uSnn/+eZ8t8hvszpw5ozVr1kiSevfurf/4j//wSr+Mb9/YsmWLDh486Phz7ViVzq+ZV/fbNEmaPn36RX348rz78MMP6/3339f+/fv1yCOP6ODBg7r99tsVGRmpTZs26dlnn5XNZlNkZKR+//vfux2nJfP0mB86dEg33HCDY6HMZ555Rq1bt270PJ+UlNTgo3obs2DBAt15552aOHGiBg8erO7duysmJkZnz57Vtm3b9Nprrzk+93v16qV58+a5HKOl8/R4Hz16VCNGjNDAgQM1duxYXXnllY5jefjwYa1YsUIrVqxwfCP/0ksvuTxLt6758+frr3/9q/Lz83XHHXcoOztbN998syRpzZo1evnllyWdvx34mWeecTtOS+WNz/S6li9f7ni0tbdn7zC+3eeta62gPX83a/koCK1atcqIi4tzVPB+/JOWltbgt7bOzOAxDMOw2+3Gz3/+8wZjSDLuvvtuw263N9O7DG6N/b3X99OlS5d6+2nqG/66+xv7SUxMNFauXNm8bzqIdenSxanjMGnSJOPMmTP19uHMDB7DOP9Nwk033dRgjJCQkEZfD+979dVXG/1GpiGM78BQ91s3Z34a4o3zrjPfABqGYRw4cMDo2bNng3Hi4uKM1atXe/LX0qJ5esydHZt1fxr6XG7qG/66+xv7GTZsWIOzRoKdp8e77u/ejf1ERUUZixYtajQXZ2bwGIZhbN++3ejQoUODsTp06GBs377d07+aFslbn+m1rr76akOSYbVajby8PJdyYXw3H1c/gxu61jKM4Dx/M4PHy8aOHat//vOfeuWVV7R27Vrl5uYqLCxMPXr00K233qo5c+YoKirKoxghISFasmSJJk2apMWLF2vnzp0qKChQ27Zt1b9/f82ePduni4Ciedx0001asmSJsrKytHv3bp06dUqFhYUyDEMJCQm68sordeONN2r69OmKi4vzd7ot1p///GdlZmYqKytLhw8fVkFBgYqLixUTE6PU1FRde+21mjZtmgYOHOhxrMjISK1du1bvvvuuli1bpq+++kpFRUVq3769hgwZojlz5nglDpz31ltvSTo/i+bOO+/0Wr+Mb3Px5Xm3R48e2r17t/7whz/oww8/1MGDB1VVVaXU1FTddNNNeuCBB9SlSxevxIJ/vfTSS9q4caOysrK0b98+FRQUqKioSFFRUUpOTtbVV1+tO+64QxkZGayn2Ez69u2rt99+W1lZWcrOzlZeXp4KCgpks9nUpk0bXX755br++us1c+ZMt2Zp1efqq6/Wnj179Morr2jlypU6evSopPOLwo4fP14PPvig45HsaD4HDhzQl19+KUkaNWqUOnTo4NX+Gd+BIRjP3xbDaGAVIAAAAAAAAJgCT9ECAAAAAAAwOQo8AAAAAAAAJkeBBwAAAAAAwOQo8AAAAAAAAJgcBR4AAAAAAACTo8ADAAAAAABgchR4AAAAAAAATI4CDwAAAAAAgMlR4AEAAAAAADA5CjwAAAAAAAAmR4EHAAAAAADA5CjwAAAAAAAAmBwFHgAAAAAAAJOjwAMAAAAAAGByFHgAAAAAAABMjgIPAAAAAACAyVHgAQAAAAAAMDkKPAAAAAAAACZHgQcAAAAAAMDkKPAAAAAAAACYHAUeAAAAAAAAk6PAAwAAAAAAYHIUeAAAAAAAAEyOAg8AAAAAAIDJUeABAAAAAAAwuf8fGqkk3i7hMxoAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "height": 434,
+       "width": 572
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.scatter(*zip(*fp.points[:4], strict=True), s=600, color=\"cadetblue\", zorder=1)\n",
+    "plt.scatter(*zip(*fp.points[4:-4], strict=True), s=300, color=\"goldenrod\", zorder=2)\n",
+    "plt.scatter(*zip(*fp.points[-4:], strict=True), s=100, color=\"darkolivegreen\", zorder=3)\n",
+    "plt.scatter(*zip(a, b, strict=True), color=\"red\", ec=\"k\", zorder=4)\n",
+    "plt.xlim(0, 20)\n",
+    "plt.ylim(0, 20)\n",
+    "plt.title(f\"Closest pair is {dist:.2} units apart.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "935e9fea-a9a2-4b03-a6f5-7fb686d185cb",
+   "metadata": {},
+   "source": [
+    "------------------------"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,14 @@ tests = [
     "ruff",
     "setuptools_scm",
 ]
+notebooks = [
+    "jupyterlab",
+    "matplotlib",
+    "watermark"
+]
+all = [
+    "fastpair[tests,notebooks]"
+]
 
 [tool.setuptools.packages.find]
 include = ["fastpair", "fastpair.*"]
@@ -76,6 +84,10 @@ omit = ["fastpair/test/*"]
 [tool.ruff]
 line-length = 88
 lint.select = ["E", "F", "W", "I", "UP", "N", "B", "A", "C4", "SIM", "ARG"]
+include = [
+    "*.py",
+    "*.ipynb",
+]
 
 [tool.ruff.lint.per-file-ignores]
  "*__init__.py" = [


### PR DESCRIPTION
This PR:
* adds a first most basic usage notebook
   * this notebooks:
      * builds from the example in `README` but boils it down even further
      * update the points generator helper and makes it more flexible
      * provides a concise narrative and a clear visual example
 * adds notebooks reqs to `pyproject.toml`
 * updates `.precommit`
 * opting to leave the example in the `README` for now until we are more settled on the notebooks, etc.

----------------

* A follow up notebook will contain a higher dimensional points example
* What do we thing about including (something like) the points generator as a utility function within the `fastpair` package? -- One source for demos/notebooks + useful in tests/benchmarking.


xref:
* #38 
* #20 

cc @gegen07